### PR TITLE
Fix dependency on JDK8 classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-	id 'java'
-	id 'groovy'
-	id 'maven'
-	id 'signing'
-	id 'com.jfrog.bintray' version '1.0'
+    id 'java'
+    id 'groovy'
+    id 'maven'
+    id 'signing'
+    id 'com.jfrog.bintray' version '1.0'
 }
 
 if (!gradle.startParameter.taskNames.contains('release')) {
@@ -12,17 +12,17 @@ if (!gradle.startParameter.taskNames.contains('release')) {
 }
 
 repositories {
-	jcenter()
+    jcenter()
 }
 
 
 dependencies {
-	compile gradleApi()
-	
-	testCompile ('org.spockframework:spock-core:0.7-groovy-2.0') {
-		exclude group: 'org.codehaus.groovy'
-	} 
-	testCompile 'org.hamcrest:hamcrest-all:1.3'
+    compile gradleApi()
+
+    testCompile ('org.spockframework:spock-core:0.7-groovy-2.0') {
+        exclude group: 'org.codehaus.groovy'
+    }
+    testCompile 'org.hamcrest:hamcrest-all:1.3'
 }
 
 
@@ -104,29 +104,29 @@ install {
 
 
 bintray {
-	user = bintray_user
-	key = bintray_key
-	configurations = ['archives']
-	
-	pkg {
-		repo = project.bintray_repo
-		name = project.name
-		desc = project.description
-		websiteUrl = project.home_url
-		licenses = ['MIT']
-		labels = ['gradle', 'plugin', 'test', 'testset']
-		
-		vcsUrl = project.scm_url
-		issueTrackerUrl = project.issues_url
-		publicDownloadNumbers = true
-		
-		version {
-			vcsTag = project.version
-			attributes = [
-				'gradle-plugin': "org.unbroken-dome.test-sets:${project.group}:${project.name}"
-			]
-		}
-	}
+    user = bintray_user
+    key = bintray_key
+    configurations = ['archives']
+
+    pkg {
+        repo = project.bintray_repo
+        name = project.name
+        desc = project.description
+        websiteUrl = project.home_url
+        licenses = ['MIT']
+        labels = ['gradle', 'plugin', 'test', 'testset']
+
+        vcsUrl = project.scm_url
+        issueTrackerUrl = project.issues_url
+        publicDownloadNumbers = true
+
+        version {
+            vcsTag = project.version
+            attributes = [
+                'gradle-plugin': "org.unbroken-dome.test-sets:${project.group}:${project.name}"
+            ]
+        }
+    }
 }
 
 

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/TestSetsPlugin.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/TestSetsPlugin.groovy
@@ -10,18 +10,18 @@ import javax.inject.Inject
 
 public class TestSetsPlugin implements Plugin<Project> {
 
-	private final Instantiator instantiator
+    private final Instantiator instantiator
 
 
-	@Inject
-	public TestSetsPlugin(Instantiator instantiator) {
-		this.instantiator = instantiator
-	}
+    @Inject
+    public TestSetsPlugin(Instantiator instantiator) {
+        this.instantiator = instantiator
+    }
 
 
-	@Override
-	void apply(Project project) {
-		project.apply plugin: JavaPlugin
+    @Override
+    void apply(Project project) {
+        project.apply plugin: JavaPlugin
 
         project.extensions.create('testSets', DefaultTestSetContainer, instantiator)
 
@@ -31,6 +31,6 @@ public class TestSetsPlugin implements Plugin<Project> {
         instantiator.newInstance JarTaskListener, project
         instantiator.newInstance ArtifactListener, project
         instantiator.newInstance EclipseClasspathListener, project
-		instantiator.newInstance IdeaModuleListener, project
-	}
+        instantiator.newInstance IdeaModuleListener, project
+    }
 }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/dsl/ConfigurableTestSet.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/dsl/ConfigurableTestSet.groovy
@@ -1,18 +1,18 @@
-package org.unbrokendome.gradle.plugins.testsets.dsl;
+package org.unbrokendome.gradle.plugins.testsets.dsl
 
 /**
  * A {@link TestSet} whose properties can be modified.
  */
 interface ConfigurableTestSet extends TestSet {
 
-	ConfigurableTestSet extendsFrom(TestSet... superTestSets);
+    ConfigurableTestSet extendsFrom(TestSet... superTestSets)
 
 
-	void setCreateArtifact(boolean createArtifact);
+    void setCreateArtifact(boolean createArtifact)
 
 
-	void setClassifier(String classifier);
-	
-	
-	void setDirName(String dirName);
+    void setClassifier(String classifier)
+
+
+    void setDirName(String dirName)
 }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/dsl/TestSet.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/dsl/TestSet.groovy
@@ -5,34 +5,34 @@ import java.util.function.Consumer
 
 interface TestSet extends Named {
 
-	Set<TestSet> getExtendsFrom()
+    Set<TestSet> getExtendsFrom()
 
 
-	boolean isCreateArtifact()
+    boolean isCreateArtifact()
 
 
-	String getClassifier()
+    String getClassifier()
 
 
-	String getDirName()
+    String getDirName()
 
 
-	String getTestTaskName()
+    String getTestTaskName()
 
 
-	String getJarTaskName()
+    String getJarTaskName()
 
 
-	String getSourceSetName()
+    String getSourceSetName()
 
 
-	String getCompileConfigurationName()
+    String getCompileConfigurationName()
 
 
-	String getRuntimeConfigurationName()
+    String getRuntimeConfigurationName()
 
 
-	String getArtifactConfigurationName()
+    String getArtifactConfigurationName()
 
 
     void whenExtendsFromAdded(Consumer<TestSet> action)

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/dsl/TestSet.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/dsl/TestSet.groovy
@@ -1,7 +1,8 @@
 package org.unbrokendome.gradle.plugins.testsets.dsl
 
+import org.gradle.api.Action
 import org.gradle.api.Named
-import java.util.function.Consumer
+
 
 interface TestSet extends Named {
 
@@ -35,6 +36,8 @@ interface TestSet extends Named {
     String getArtifactConfigurationName()
 
 
-    void whenExtendsFromAdded(Consumer<TestSet> action)
-    void whenDirNameChanged(Consumer<String> action)
+    void whenExtendsFromAdded(Action<TestSet> action)
+
+
+    void whenDirNameChanged(Action<String> action)
 }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/dsl/TestSetContainer.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/dsl/TestSetContainer.groovy
@@ -1,6 +1,6 @@
-package org.unbrokendome.gradle.plugins.testsets.dsl;
+package org.unbrokendome.gradle.plugins.testsets.dsl
 
-import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.NamedDomainObjectContainer
 
 interface TestSetContainer extends NamedDomainObjectContainer<TestSet> {
 }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/AbstractTestSet.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/AbstractTestSet.groovy
@@ -2,46 +2,47 @@ package org.unbrokendome.gradle.plugins.testsets.internal
 
 import org.unbrokendome.gradle.plugins.testsets.dsl.TestSet
 
+
 abstract class AbstractTestSet implements TestSet {
 
-	@Override
-	String getTestTaskName() {
-		name
+    @Override
+    String getTestTaskName() {
+        name
     }
 
 
-	@Override
-	String getJarTaskName() {
-		"${name}Jar"
-	}
+    @Override
+    String getJarTaskName() {
+        "${name}Jar"
+    }
 
 
-	@Override
-	String getSourceSetName() {
-		name;
-	}
+    @Override
+    String getSourceSetName() {
+        name
+    }
 
 
-	@Override
-	String getCompileConfigurationName() {
-		"${name}Compile"
-	}
+    @Override
+    String getCompileConfigurationName() {
+        "${name}Compile"
+    }
 
 
-	@Override
-	String getRuntimeConfigurationName() {
-		"${name}Runtime"
-	}
+    @Override
+    String getRuntimeConfigurationName() {
+        "${name}Runtime"
+    }
 
 
-	@Override
-	String getArtifactConfigurationName() {
-		name
-	}
+    @Override
+    String getArtifactConfigurationName() {
+        name
+    }
 
 
-	@Override
-	String getClassifier() {
-		name
-	}
+    @Override
+    String getClassifier() {
+        name
+    }
 }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/ArtifactListener.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/ArtifactListener.groovy
@@ -4,33 +4,34 @@ import org.gradle.api.Project
 import org.unbrokendome.gradle.plugins.testsets.dsl.TestSet
 import org.unbrokendome.gradle.plugins.testsets.dsl.TestSetContainer
 
+
 class ArtifactListener {
 
-	private final Project project
+    private final Project project
 
 
-	ArtifactListener(Project project) {
-		this.project = project
+    ArtifactListener(Project project) {
+        this.project = project
 
         def testSets = project.testSets as TestSetContainer
         testSets.whenObjectAdded { testSetAdded(it) }
-	}
+    }
 
 
-	void testSetAdded(TestSet testSet) {
+    void testSetAdded(TestSet testSet) {
 
-		project.afterEvaluate { project ->
+        project.afterEvaluate { project ->
 
             if (testSet.createArtifact) {
 
                 project.configurations.maybeCreate testSet.artifactConfigurationName
 
-                def jarTask = project.tasks.findByName(testSet.jarTaskName);
+                def jarTask = project.tasks.findByName(testSet.jarTaskName)
 
                 project.artifacts.add(testSet.artifactConfigurationName, jarTask) {
                     classifier = testSet.classifier
                 }
             }
-		}
-	}
+        }
+    }
 }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/ConfigurationDependencyListener.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/ConfigurationDependencyListener.groovy
@@ -5,17 +5,18 @@ import org.gradle.api.artifacts.ConfigurationContainer
 import org.unbrokendome.gradle.plugins.testsets.dsl.TestSet
 import org.unbrokendome.gradle.plugins.testsets.dsl.TestSetContainer
 
+
 class ConfigurationDependencyListener {
 
-	private final Project project;
+    private final Project project
 
 
-	ConfigurationDependencyListener(Project project) {
-		this.project = project;
+    ConfigurationDependencyListener(Project project) {
+        this.project = project
 
         def testSets = project.testSets as TestSetContainer
         testSets.whenObjectAdded { testSetAdded(it) }
-	}
+    }
 
 
     void testSetAdded(TestSet testSet) {
@@ -23,14 +24,14 @@ class ConfigurationDependencyListener {
     }
 
 
-	void extendsFromAdded(TestSet testSet, TestSet superTestSet) {
-		addConfigurationExtension testSet.compileConfigurationName, superTestSet.compileConfigurationName
-		addConfigurationExtension testSet.runtimeConfigurationName, superTestSet.runtimeConfigurationName
-	}
+    void extendsFromAdded(TestSet testSet, TestSet superTestSet) {
+        addConfigurationExtension testSet.compileConfigurationName, superTestSet.compileConfigurationName
+        addConfigurationExtension testSet.runtimeConfigurationName, superTestSet.runtimeConfigurationName
+    }
 
 
-	private void addConfigurationExtension(String configurationName, String superConfigurationName) {
-		ConfigurationContainer configurations = project.configurations;
+    private void addConfigurationExtension(String configurationName, String superConfigurationName) {
+        ConfigurationContainer configurations = project.configurations
         configurations[configurationName].extendsFrom configurations[superConfigurationName]
-	}
+    }
 }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/DefaultTestSet.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/DefaultTestSet.groovy
@@ -1,10 +1,10 @@
 package org.unbrokendome.gradle.plugins.testsets.internal
 
+import org.gradle.api.Action
 import org.unbrokendome.gradle.plugins.testsets.dsl.ConfigurableTestSet
 import org.unbrokendome.gradle.plugins.testsets.dsl.TestSet
 
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.function.Consumer
 
 
 class DefaultTestSet extends AbstractTestSet implements ConfigurableTestSet {
@@ -14,8 +14,8 @@ class DefaultTestSet extends AbstractTestSet implements ConfigurableTestSet {
     private String dirName
     boolean createArtifact = true
     String classifier
-    private final List<Consumer<TestSet>> extendsFromAddedListeners = new CopyOnWriteArrayList<>()
-    private final List<Consumer<String>> dirNameChangeListeners = new CopyOnWriteArrayList<>()
+    private final List<Action<TestSet>> extendsFromAddedListeners = new CopyOnWriteArrayList<>()
+    private final List<Action<String>> dirNameChangeListeners = new CopyOnWriteArrayList<>()
 
 
     DefaultTestSet(String name) {
@@ -32,7 +32,7 @@ class DefaultTestSet extends AbstractTestSet implements ConfigurableTestSet {
     @Override
     void setDirName(String dirName) {
         this.dirName = dirName
-        dirNameChangeListeners.each { it.accept dirName }
+        dirNameChangeListeners.each { it.execute dirName }
     }
 
 
@@ -45,7 +45,7 @@ class DefaultTestSet extends AbstractTestSet implements ConfigurableTestSet {
     private ConfigurableTestSet extendsFromInternal(Collection<TestSet> superTestSets) {
         for (superTestSet in superTestSets) {
             extendsFrom << superTestSet
-            extendsFromAddedListeners.each { it.accept superTestSet }
+            extendsFromAddedListeners.each { it.execute superTestSet }
         }
         this
     }
@@ -64,13 +64,13 @@ class DefaultTestSet extends AbstractTestSet implements ConfigurableTestSet {
 
 
     @Override
-    void whenExtendsFromAdded(Consumer<TestSet> action) {
+    void whenExtendsFromAdded(Action<TestSet> action) {
         extendsFromAddedListeners << action
     }
 
 
     @Override
-    void whenDirNameChanged(Consumer<String> action) {
+    void whenDirNameChanged(Action<String> action) {
         dirNameChangeListeners << action
     }
 }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/DefaultTestSet.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/DefaultTestSet.groovy
@@ -6,60 +6,61 @@ import org.unbrokendome.gradle.plugins.testsets.dsl.TestSet
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.function.Consumer
 
+
 class DefaultTestSet extends AbstractTestSet implements ConfigurableTestSet {
 
-	final String name;
-	private final Set<TestSet> extendsFrom = []
+    final String name
+    private final Set<TestSet> extendsFrom = []
     private String dirName
-	boolean createArtifact = true
-	String classifier
+    boolean createArtifact = true
+    String classifier
     private final List<Consumer<TestSet>> extendsFromAddedListeners = new CopyOnWriteArrayList<>()
     private final List<Consumer<String>> dirNameChangeListeners = new CopyOnWriteArrayList<>()
 
 
-	DefaultTestSet(String name) {
-		this.name = name
-	}
+    DefaultTestSet(String name) {
+        this.name = name
+    }
 
-	
-	@Override
-	String getDirName() {
+
+    @Override
+    String getDirName() {
         dirName ?: name
-	}
-	
-	
-	@Override
-	void setDirName(String dirName) {
-		this.dirName = dirName;
+    }
+
+
+    @Override
+    void setDirName(String dirName) {
+        this.dirName = dirName
         dirNameChangeListeners.each { it.accept dirName }
-	}
+    }
 
 
-	@Override
-	ConfigurableTestSet extendsFrom(TestSet... superTestSets) {
-		extendsFromInternal Arrays.asList(superTestSets)
-	}
+    @Override
+    ConfigurableTestSet extendsFrom(TestSet... superTestSets) {
+        extendsFromInternal Arrays.asList(superTestSets)
+    }
 
 
-	private ConfigurableTestSet extendsFromInternal(Collection<TestSet> superTestSets) {
+    private ConfigurableTestSet extendsFromInternal(Collection<TestSet> superTestSets) {
         for (superTestSet in superTestSets) {
             extendsFrom << superTestSet
             extendsFromAddedListeners.each { it.accept superTestSet }
         }
-		this
-	}
+        this
+    }
 
 
-	@Override
-	Set<TestSet> getExtendsFrom() {
-		return Collections.unmodifiableSet(this.extendsFrom)
-	}
+    @Override
+    Set<TestSet> getExtendsFrom() {
+        return Collections.unmodifiableSet(this.extendsFrom)
+    }
 
 
-	@Override
-	String getClassifier() {
-		classifier ?: name
-	}
+    @Override
+    String getClassifier() {
+        classifier ?: name
+    }
 
 
     @Override

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/DefaultTestSetContainer.java
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/DefaultTestSetContainer.java
@@ -8,32 +8,32 @@ import org.unbrokendome.gradle.plugins.testsets.dsl.TestSetContainer;
 
 public class DefaultTestSetContainer extends AbstractNamedDomainObjectContainer<TestSet> implements TestSetContainer {
 
-	private final TestSet predefinedUnitTestSet = new PredefinedUnitTestSet();
-	
-	
-	public DefaultTestSetContainer(Instantiator instantiator) {
-		super(TestSet.class, instantiator);
-		super.add(predefinedUnitTestSet);
-	}
-	
+    private final TestSet predefinedUnitTestSet = new PredefinedUnitTestSet();
 
-	@Override
-	protected TestSet doCreate(String name) {
-		return new DefaultTestSet(name);
-	}
 
-	
-	@Override
-	public boolean add(TestSet testSet) {
-		
-		boolean added = super.add(testSet);
-		
-		if (added) {
-			if (testSet instanceof ConfigurableTestSet) {
-				((ConfigurableTestSet) testSet).extendsFrom(predefinedUnitTestSet);
-			}
-		}
-		
-		return added;
-	}
+    public DefaultTestSetContainer(Instantiator instantiator) {
+        super(TestSet.class, instantiator);
+        super.add(predefinedUnitTestSet);
+    }
+
+
+    @Override
+    protected TestSet doCreate(String name) {
+        return new DefaultTestSet(name);
+    }
+
+
+    @Override
+    public boolean add(TestSet testSet) {
+
+        boolean added = super.add(testSet);
+
+        if (added) {
+            if (testSet instanceof ConfigurableTestSet) {
+                ((ConfigurableTestSet) testSet).extendsFrom(predefinedUnitTestSet);
+            }
+        }
+
+        return added;
+    }
 }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/EclipseClasspathListener.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/EclipseClasspathListener.groovy
@@ -10,32 +10,33 @@ import org.unbrokendome.gradle.plugins.testsets.dsl.TestSetContainer
 
 import java.nio.file.Paths
 
+
 class EclipseClasspathListener {
 
-	private final Project project;
+    private final Project project
 
 
-	EclipseClasspathListener(Project project) {
-		this.project = project
+    EclipseClasspathListener(Project project) {
+        this.project = project
 
         def testSets = project.testSets as TestSetContainer
         testSets.whenObjectAdded { testSetAdded(it) }
-	}
+    }
 
 
-	void testSetAdded(TestSet testSet) {
-		
-		def eclipseModel = project.extensions.findByType EclipseModel
-		if (eclipseModel) {
+    void testSetAdded(TestSet testSet) {
 
-			def eclipseClasspath = eclipseModel.classpath;
+        def eclipseModel = project.extensions.findByType EclipseModel
+        if (eclipseModel) {
+
+            def eclipseClasspath = eclipseModel.classpath
 
             addConfigurationToClasspath testSet.compileConfigurationName, eclipseClasspath
             addConfigurationToClasspath testSet.runtimeConfigurationName, eclipseClasspath
 
             applyClasspathFix eclipseClasspath
         }
-	}
+    }
 
 
     private void addConfigurationToClasspath(String configurationName, EclipseClasspath eclipseClasspath) {

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/IdeaModuleListener.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/IdeaModuleListener.groovy
@@ -10,13 +10,14 @@ import org.unbrokendome.gradle.plugins.testsets.dsl.TestSetContainer
 
 import java.nio.file.Paths
 
+
 public class IdeaModuleListener {
 
-    final Project project;
+    private final Project project
 
 
     public IdeaModuleListener(Project project) {
-        this.project = project;
+        this.project = project
 
         def testSets = project.testSets as TestSetContainer
         testSets.whenObjectAdded { testSetAdded(it) }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/IdeaModuleListener.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/IdeaModuleListener.groovy
@@ -13,7 +13,7 @@ import java.nio.file.Paths
 
 public class IdeaModuleListener {
 
-    private final Project project
+    final Project project
 
 
     public IdeaModuleListener(Project project) {

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/JarTaskListener.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/JarTaskListener.groovy
@@ -6,20 +6,21 @@ import org.gradle.api.tasks.bundling.Jar
 import org.unbrokendome.gradle.plugins.testsets.dsl.TestSet
 import org.unbrokendome.gradle.plugins.testsets.dsl.TestSetContainer
 
+
 class JarTaskListener {
 
-	private final Project project;
+    private final Project project
 
 
-	JarTaskListener(Project project) {
-		this.project = project;
+    JarTaskListener(Project project) {
+        this.project = project
 
         def testSets = project.testSets as TestSetContainer
         testSets.whenObjectAdded { testSetAdded(it) }
     }
 
 
-	void testSetAdded(TestSet testSet) {
+    void testSetAdded(TestSet testSet) {
 
         def jarTask = project.tasks.create(testSet.jarTaskName, Jar) {
             from {
@@ -35,5 +36,5 @@ class JarTaskListener {
 
             map('classifier') { testSet.classifier }
         }
-	}
+    }
 }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/PredefinedUnitTestSet.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/PredefinedUnitTestSet.groovy
@@ -7,57 +7,58 @@ import org.unbrokendome.gradle.plugins.testsets.dsl.TestSet
 import java.util.function.BiConsumer
 import java.util.function.Consumer
 
+
 class PredefinedUnitTestSet extends AbstractTestSet {
 
-	static final String NAME = "unitTest"
+    static final String NAME = "unitTest"
 
 
-	@Override
-	String getName() {
-		NAME
-	}
-	
-
-	@Override
-	boolean isCreateArtifact() {
-		false
-	}
-
-	
-	@Override
-	String getDirName() {
-		SourceSet.TEST_SOURCE_SET_NAME
-	}
-	
-
-	@Override
-	Set<TestSet> getExtendsFrom() {
-		Collections.emptySet()
-	}
+    @Override
+    String getName() {
+        NAME
+    }
 
 
-	@Override
-	String getTestTaskName() {
-		JavaPlugin.TEST_TASK_NAME
-	}
+    @Override
+    boolean isCreateArtifact() {
+        false
+    }
 
 
-	@Override
-	String getSourceSetName() {
-		SourceSet.TEST_SOURCE_SET_NAME
-	}
+    @Override
+    String getDirName() {
+        SourceSet.TEST_SOURCE_SET_NAME
+    }
 
 
-	@Override
-	String getCompileConfigurationName() {
-		JavaPlugin.TEST_COMPILE_CONFIGURATION_NAME
-	}
+    @Override
+    Set<TestSet> getExtendsFrom() {
+        Collections.emptySet()
+    }
 
 
-	@Override
-	String getRuntimeConfigurationName() {
-		JavaPlugin.TEST_RUNTIME_CONFIGURATION_NAME
-	}
+    @Override
+    String getTestTaskName() {
+        JavaPlugin.TEST_TASK_NAME
+    }
+
+
+    @Override
+    String getSourceSetName() {
+        SourceSet.TEST_SOURCE_SET_NAME
+    }
+
+
+    @Override
+    String getCompileConfigurationName() {
+        JavaPlugin.TEST_COMPILE_CONFIGURATION_NAME
+    }
+
+
+    @Override
+    String getRuntimeConfigurationName() {
+        JavaPlugin.TEST_RUNTIME_CONFIGURATION_NAME
+    }
 
 
     @Override

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/PredefinedUnitTestSet.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/PredefinedUnitTestSet.groovy
@@ -1,11 +1,9 @@
 package org.unbrokendome.gradle.plugins.testsets.internal
 
+import org.gradle.api.Action
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.SourceSet
 import org.unbrokendome.gradle.plugins.testsets.dsl.TestSet
-
-import java.util.function.BiConsumer
-import java.util.function.Consumer
 
 
 class PredefinedUnitTestSet extends AbstractTestSet {
@@ -62,11 +60,11 @@ class PredefinedUnitTestSet extends AbstractTestSet {
 
 
     @Override
-    void whenExtendsFromAdded(Consumer<TestSet> action) {
+    void whenExtendsFromAdded(Action<TestSet> action) {
     }
 
 
     @Override
-    void whenDirNameChanged(Consumer<String> action) {
+    void whenDirNameChanged(Action<String> action) {
     }
 }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/SourceSetListener.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/SourceSetListener.groovy
@@ -7,69 +7,69 @@ import org.gradle.api.tasks.SourceSet
 import org.unbrokendome.gradle.plugins.testsets.dsl.TestSet
 import org.unbrokendome.gradle.plugins.testsets.dsl.TestSetContainer
 
+
 class SourceSetListener {
-	
-	private final Project project
-	
-	
-	SourceSetListener(Project project) {
-		this.project = project
+
+    private final Project project
+
+
+    SourceSetListener(Project project) {
+        this.project = project
 
         def testSets = project.testSets as TestSetContainer
         testSets.whenObjectAdded { testSetAdded(it) }
-	}
-	
+    }
 
-	void testSetAdded(TestSet testSet) {
-		createSourceSet(testSet)
-		createDependency(testSet)
+
+    void testSetAdded(TestSet testSet) {
+        createSourceSet(testSet)
+        createDependency(testSet)
 
         testSet.whenDirNameChanged { dirNameChanged(testSet) }
-	}
+    }
 
 
-	private void createSourceSet(TestSet testSet) {
-		// Remember: creating a SourceSet will also implicitly create a compile and runtime configuration
-		project.sourceSets.create testSet.sourceSetName
-	}
+    private void createSourceSet(TestSet testSet) {
+        // Remember: creating a SourceSet will also implicitly create a compile and runtime configuration
+        project.sourceSets.create testSet.sourceSetName
+    }
 
 
-	private void createDependency(TestSet testSet) {
+    private void createDependency(TestSet testSet) {
         project.dependencies.add testSet.compileConfigurationName, getMainSourceSet().output
-	}
+    }
 
 
-	private SourceSet getMainSourceSet() {
+    private SourceSet getMainSourceSet() {
         project.sourceSets[SourceSet.MAIN_SOURCE_SET_NAME]
-	}
-	
-	
-	void dirNameChanged(TestSet testSet) {
-		String dirName = testSet.dirName
-		
-		def sourceSet = project.sourceSets[testSet.sourceSetName] as SourceSet
-		
-		applyJavaSrcDir(sourceSet, dirName)
-		applyResourcesSrcDir(sourceSet, dirName)
-		applyGroovySrcDir(sourceSet, dirName)
-	}
+    }
 
 
-	private void applyResourcesSrcDir(SourceSet sourceSet, String dirName) {
+    void dirNameChanged(TestSet testSet) {
+        String dirName = testSet.dirName
+
+        def sourceSet = project.sourceSets[testSet.sourceSetName] as SourceSet
+
+        applyJavaSrcDir(sourceSet, dirName)
+        applyResourcesSrcDir(sourceSet, dirName)
+        applyGroovySrcDir(sourceSet, dirName)
+    }
+
+
+    private void applyResourcesSrcDir(SourceSet sourceSet, String dirName) {
         sourceSet.resources.srcDirs = [ "src/$dirName/resources" ]
-	}
+    }
 
 
-	private void applyJavaSrcDir(SourceSet sourceSet, String dirName) {
+    private void applyJavaSrcDir(SourceSet sourceSet, String dirName) {
         sourceSet.java.srcDirs = [ "src/$dirName/java" ]
-	}
-	
-	
-	private void applyGroovySrcDir(SourceSet sourceSet, String dirName) {
-		def groovySourceSet = new DslObject(sourceSet).convention.findPlugin GroovySourceSet
-		if (groovySourceSet != null) {
-            groovySourceSet.groovy.srcDirs = [ "src/$dirName/groovy" ]
-		}
-	}
+    }
 
+
+    private void applyGroovySrcDir(SourceSet sourceSet, String dirName) {
+        def groovySourceSet = new DslObject(sourceSet).convention.findPlugin GroovySourceSet
+        if (groovySourceSet != null) {
+            groovySourceSet.groovy.srcDirs = [ "src/$dirName/groovy" ]
+        }
+    }
 }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskListener.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskListener.groovy
@@ -10,7 +10,7 @@ import org.unbrokendome.gradle.plugins.testsets.dsl.TestSetContainer
 
 class TestTaskListener {
 
-    private final Project project
+    final Project project
 
 
     TestTaskListener(Project project) {

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskListener.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskListener.groovy
@@ -7,21 +7,22 @@ import org.gradle.api.tasks.testing.Test
 import org.unbrokendome.gradle.plugins.testsets.dsl.TestSet
 import org.unbrokendome.gradle.plugins.testsets.dsl.TestSetContainer
 
+
 class TestTaskListener {
 
-	final Project project
+    private final Project project
 
 
-	TestTaskListener(Project project) {
-		this.project = project;
+    TestTaskListener(Project project) {
+        this.project = project
 
         def testSets = project.testSets as TestSetContainer
         testSets.whenObjectAdded { testSetAdded(it) }
-	}
+    }
 
 
-	void testSetAdded(TestSet testSet) {
-		def testTask = project.tasks.create testSet.testTaskName, Test
+    void testSetAdded(TestSet testSet) {
+        def testTask = project.tasks.create testSet.testTaskName, Test
 
         testTask.conventionMapping.with {
             map('description') { "Runs the ${testSet.name} tests" }
@@ -41,5 +42,5 @@ class TestTaskListener {
 
         testTask.reports.html.destination = new File(project.buildDir, testSet.name)
         testTask.reports.junitXml.destination = new File(project.buildDir, "${testSet.name}-results")
-	}
+    }
 }

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/ArtifactTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/ArtifactTest.groovy
@@ -1,49 +1,48 @@
 package org.unbrokendome.gradle.plugins.testsets
 
-import static org.hamcrest.Matchers.*
-
 import org.gradle.api.Project
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.testfixtures.ProjectBuilder
 
 import spock.lang.Specification
+
+import static org.hamcrest.Matchers.*
 import static spock.util.matcher.HamcrestSupport.*
 
 
-
 class ArtifactTest extends Specification {
-	
-	Project project;
-	
-	
-	def setup() {
-		project = ProjectBuilder.builder().build()
-		project.apply plugin: 'org.unbroken-dome.test-sets' 
-	}
-	
-	
-	def "New test set should have associated artifact configuration"() {
-		when:
-			project.testSets {
-				myTest { createArtifact = true }
-			}
-		and:
-			project.evaluate()
-			
-		then:
-			project.configurations['myTest']
-	}
-	
-	
-	def "New test set should have associated artifact"() {
-		when:
-			project.testSets {
-				myTest { createArtifact = true }
-			}
-		and:
-			project.evaluate()
-			
-		then:
-			expect project.configurations['myTest'].artifacts, not(empty())
-	}
+
+    Project project
+
+
+    def setup() {
+        project = ProjectBuilder.builder().build()
+        project.apply plugin: 'org.unbroken-dome.test-sets'
+    }
+
+
+    def "New test set should have associated artifact configuration"() {
+        when:
+            project.testSets {
+                myTest { createArtifact = true }
+            }
+        and:
+            project.evaluate()
+
+        then:
+            project.configurations['myTest']
+    }
+
+
+    def "New test set should have associated artifact"() {
+        when:
+            project.testSets {
+                myTest { createArtifact = true }
+            }
+        and:
+            project.evaluate()
+
+        then:
+            expect project.configurations['myTest'].artifacts, not(empty())
+    }
 }

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/EclipseClasspathTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/EclipseClasspathTest.groovy
@@ -8,24 +8,24 @@ import spock.lang.Specification
 
 
 class EclipseClasspathTest extends Specification {
-	
-	Project project;
-	
-	
-	def setup() {
-		project = ProjectBuilder.builder().build()
-		project.apply plugin: 'eclipse'
-		project.apply plugin: 'org.unbroken-dome.test-sets'
-	}
-	
-	
-	def "Test set classpath should be added to classpath container"() {
-		when:
-			project.testSets { myTest }
-		
-		then:
-			project.eclipse.classpath
-	}
-	
+
+    Project project
+
+
+    def setup() {
+        project = ProjectBuilder.builder().build()
+        project.apply plugin: 'eclipse'
+        project.apply plugin: 'org.unbroken-dome.test-sets'
+    }
+
+
+    def "Test set classpath should be added to classpath container"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            project.eclipse.classpath
+    }
+
 
 }

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/IdeaModuleTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/IdeaModuleTest.groovy
@@ -7,7 +7,7 @@ import spock.lang.Specification
 
 class IdeaModuleTest extends Specification {
 
-    Project project;
+    Project project
 
 
     def setup() {

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/JarTaskTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/JarTaskTest.groovy
@@ -12,20 +12,21 @@ import spock.lang.Specification
 
 
 class JarTaskTest extends Specification {
-	
-	Project project;
-	
-	
-	def setup() {
-		project = ProjectBuilder.builder().build()
-		project.apply plugin: 'org.unbroken-dome.test-sets'
-	}
-	
-	
-	def "New test set should have associated jar task"() {
-		when:
-			project.testSets { myTest }
-		then:
-			project.tasks['myTestJar'] instanceof Jar
-	}
+
+    Project project
+
+
+    def setup() {
+        project = ProjectBuilder.builder().build()
+        project.apply plugin: 'org.unbroken-dome.test-sets'
+    }
+
+
+    def "New test set should have associated jar task"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            project.tasks['myTestJar'] instanceof Jar
+    }
 }

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/PredefinedUnitTestSetTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/PredefinedUnitTestSetTest.groovy
@@ -7,44 +7,45 @@ import spock.lang.Specification
 
 
 public class PredefinedUnitTestSetTest extends Specification {
-	
-	Project project;
-	
-	
-	def setup() {
-		project = ProjectBuilder.builder().build()
-		project.apply plugin: 'org.unbroken-dome.test-sets'
-	}
-	
-	
-	def "Project has one predefined 'unitTest' test set"() {
-		expect:
-			project.testSets['unitTest']
-	}
-	
-	
-	def "Predefined 'unitTest' test set has source set 'test'"() {
-		expect:
-			project.testSets['unitTest'].sourceSetName == 'test'
-	}
-	
-	
-	def "Predefined 'unitTest' test set has compile configuration 'testCompile'"() {
-		expect:
-			project.testSets['unitTest'].compileConfigurationName == 'testCompile'
-	}
-	
-	
-	def "Predefined 'unitTest' test set has runtime configuration 'testRuntime'"() {
-		expect:
-			project.testSets['unitTest'].runtimeConfigurationName == 'testRuntime'
-	}
-	
-	
-	def "New test set should extend from 'unitTest' test set"() {
-		when:
-			project.testSets { myTest }
-		then:
-			project.testSets['myTest'].extendsFrom == [ project.testSets['unitTest'] ].toSet()
-	}
+
+    Project project
+
+
+    def setup() {
+        project = ProjectBuilder.builder().build()
+        project.apply plugin: 'org.unbroken-dome.test-sets'
+    }
+
+
+    def "Project has one predefined 'unitTest' test set"() {
+        expect:
+            project.testSets['unitTest']
+    }
+
+
+    def "Predefined 'unitTest' test set has source set 'test'"() {
+        expect:
+            project.testSets['unitTest'].sourceSetName == 'test'
+    }
+
+
+    def "Predefined 'unitTest' test set has compile configuration 'testCompile'"() {
+        expect:
+            project.testSets['unitTest'].compileConfigurationName == 'testCompile'
+    }
+
+
+    def "Predefined 'unitTest' test set has runtime configuration 'testRuntime'"() {
+        expect:
+            project.testSets['unitTest'].runtimeConfigurationName == 'testRuntime'
+    }
+
+
+    def "New test set should extend from 'unitTest' test set"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            project.testSets['myTest'].extendsFrom == [ project.testSets['unitTest'] ].toSet()
+    }
 }

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/SourceSetTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/SourceSetTest.groovy
@@ -8,79 +8,83 @@ import spock.lang.Specification
 
 public class SourceSetTest extends Specification {
 
-	Project project;
-	
-	
-	def setup() {
-		project = ProjectBuilder.builder().build()
-		project.apply plugin: 'org.unbroken-dome.test-sets'
-	}
-	
-	
-	def "New test set should have an associated source set"() {
-		when:
-			project.testSets { myTest }
-		then:
-			project.sourceSets['myTest']
-	}
-	
-	
-	def "New test set should have an associated compile configuration"() {
-		when:
-			project.testSets { myTest }
-		then:
-			project.configurations['myTestCompile']
-	}
-	
-	
-	def "New test set should have an associated runtime configuration"() {
-		when:
-			project.testSets { myTest }
-		then:
-			project.configurations['myTestRuntime']
-	}
-	
-	
-	def "New test set's compile configuration should depend on the main source set's output"() {
-		when:
-			project.testSets { myTest }
-		then:
-			project.configurations['myTestCompile'].dependencies.any { dep ->
-				dep.contentEquals project.dependencies.create(project.sourceSets['main'].output)
-			}
-	}
-	
-	
-	def "Source set should use test set's dirName for java srcDir if given"() {
-		when:
-			project.testSets {
-				myTest { dirName = 'my-test' }
-			}
-			
-		then:
-			project.sourceSets['myTest'].java.srcDirs == [ project.file('src/my-test/java') ] as Set
-	}
-	
-	
-	def "Source set should use test set's dirName for resources srcDir if given"() {
-		when:
-			project.testSets {
-				myTest { dirName = 'my-test' }
-			}
-			
-		then:
-			project.sourceSets['myTest'].resources.srcDirs == [ project.file('src/my-test/resources') ] as Set
-	}
-	
-	
-	def "Source set should use test set's dirName for groovy srcDir if given"() {
-		when:
-			project.apply plugin: 'groovy'
-			project.testSets {
-				myTest { dirName = 'my-test' }
-			}
-			
-		then:
-			project.sourceSets['myTest'].groovy.srcDirs == [ project.file('src/my-test/groovy') ] as Set
-	}
+    Project project
+
+
+    def setup() {
+        project = ProjectBuilder.builder().build()
+        project.apply plugin: 'org.unbroken-dome.test-sets'
+    }
+
+
+    def "New test set should have an associated source set"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            project.sourceSets['myTest']
+    }
+
+
+    def "New test set should have an associated compile configuration"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            project.configurations['myTestCompile']
+    }
+
+
+    def "New test set should have an associated runtime configuration"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            project.configurations['myTestRuntime']
+    }
+
+
+    def "New test set's compile configuration should depend on the main source set's output"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            project.configurations['myTestCompile'].dependencies.any { dep ->
+                dep.contentEquals project.dependencies.create(project.sourceSets['main'].output)
+            }
+    }
+
+
+    def "Source set should use test set's dirName for java srcDir if given"() {
+        when:
+            project.testSets {
+                myTest { dirName = 'my-test' }
+            }
+
+        then:
+            project.sourceSets['myTest'].java.srcDirs == [ project.file('src/my-test/java') ] as Set
+    }
+
+
+    def "Source set should use test set's dirName for resources srcDir if given"() {
+        when:
+            project.testSets {
+                myTest { dirName = 'my-test' }
+            }
+
+        then:
+            project.sourceSets['myTest'].resources.srcDirs == [ project.file('src/my-test/resources') ] as Set
+    }
+
+
+    def "Source set should use test set's dirName for groovy srcDir if given"() {
+        when:
+            project.apply plugin: 'groovy'
+            project.testSets {
+                myTest { dirName = 'my-test' }
+            }
+
+        then:
+            project.sourceSets['myTest'].groovy.srcDirs == [ project.file('src/my-test/groovy') ] as Set
+    }
 }

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestTaskTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestTaskTest.groovy
@@ -8,40 +8,43 @@ import spock.lang.Specification
 
 
 class TestTaskTest extends Specification {
-	
-	Project project;
-	
-	
-	def setup() {
-		project = ProjectBuilder.builder().build()
-		project.apply plugin: 'org.unbroken-dome.test-sets'
-	}
-	
-	
-	def "New test set should have associated test task"() {
-		when:
-			project.testSets { myTest }
-		then:
-			project.tasks['myTest'] instanceof Test
-	}
+
+    Project project
 
 
-	def "HTML report output directory should be the name of the test set"() {
-		when:
-			project.testSets { myTest }
-		then:
-			def testTask = project.tasks['myTest'] as Test
-			def htmlReportDir = project.file(testTask.reports.html.destination)
-			htmlReportDir == new File(project.buildDir, 'myTest')
-	}
+    def setup() {
+        project = ProjectBuilder.builder().build()
+        project.apply plugin: 'org.unbroken-dome.test-sets'
+    }
 
 
-	def "JUnitXML report output directory should be the based on the name of the test set"() {
-		when:
-			project.testSets { myTest }
-		then:
-			def testTask = project.tasks['myTest'] as Test
-			def htmlReportDir = project.file(testTask.reports.junitXml.destination)
-			htmlReportDir == new File(project.buildDir, 'myTest-results')
-	}
+    def "New test set should have associated test task"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            project.tasks['myTest'] instanceof Test
+    }
+
+
+    def "HTML report output directory should be the name of the test set"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            def testTask = project.tasks['myTest'] as Test
+            def htmlReportDir = project.file(testTask.reports.html.destination)
+            htmlReportDir == new File(project.buildDir, 'myTest')
+    }
+
+
+    def "JUnitXML report output directory should be the based on the name of the test set"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            def testTask = project.tasks['myTest'] as Test
+            def htmlReportDir = project.file(testTask.reports.junitXml.destination)
+            htmlReportDir == new File(project.buildDir, 'myTest-results')
+    }
 }

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestsPluginTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestsPluginTest.groovy
@@ -9,41 +9,44 @@ import spock.lang.Specification
 
 public class TestsPluginTest extends Specification {
 
-	Project project;
-	
-	
-	def setup() {
-		project = ProjectBuilder.builder().build()
-		project.apply plugin: 'org.unbroken-dome.test-sets'
-	}
-	
-	
-	def "Test sets extension should be created"() {	
-		expect:
-			project.testSets
-	}
+    Project project
 
-	
-	def "New test set's compile configuration should extend the testCompile configuration"() {
-		when:
-			project.testSets { myTest }
-		then:
-			project.configurations['myTestCompile'].extendsFrom == [ project.configurations['testCompile'] ].toSet()
-	}
-	
-	
-	def "New test set should have an associated runtime configuration"() {
-		when:
-			project.testSets { myTest }
-		then:
-			project.configurations['myTestRuntime']
-	}
-	
-	
-	def "New test set's runtime configuration should extend the testRuntime configuration"() {
-		when:
-			project.testSets { myTest }
-		then:
-			project.configurations['myTestRuntime'].extendsFrom.contains project.configurations['testRuntime']
-	}
+
+    def setup() {
+        project = ProjectBuilder.builder().build()
+        project.apply plugin: 'org.unbroken-dome.test-sets'
+    }
+
+
+    def "Test sets extension should be created"() {
+        expect:
+            project.testSets
+    }
+
+
+    def "New test set's compile configuration should extend the testCompile configuration"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            project.configurations['myTestCompile'].extendsFrom == [ project.configurations['testCompile'] ].toSet()
+    }
+
+
+    def "New test set should have an associated runtime configuration"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            project.configurations['myTestRuntime']
+    }
+
+
+    def "New test set's runtime configuration should extend the testRuntime configuration"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            project.configurations['myTestRuntime'].extendsFrom.contains project.configurations['testRuntime']
+    }
 }


### PR DESCRIPTION
This PR removes the dependency from the `java.util.function.Consumer` interface that is only available in JDK8. The replacement used is `org.gradle.api.Action`.

I also fixed all inconsistent use of tabs and whitespace across the source files.

All tests passes with JDK 1.7.0_79.

Resolves #13 
