### PR TITLE
Fixed mixed up test-results and test reports folders.

### DIFF
--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskListener.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskListener.groovy
@@ -39,8 +39,5 @@ class TestTaskListener {
                 sourceSet.runtimeClasspath
             }
         }
-
-        testTask.reports.html.destination = new File(project.testReportDir, testSet.name)
-        testTask.reports.junitXml.destination = new File(project.testResultsDir, "${testSet.name}-results")
     }
 }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskListener.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskListener.groovy
@@ -40,7 +40,7 @@ class TestTaskListener {
             }
         }
 
-        testTask.reports.html.destination = new File(project.buildDir, testSet.name)
-        testTask.reports.junitXml.destination = new File(project.buildDir, "${testSet.name}-results")
+        testTask.reports.html.destination = new File(project.testReportDir, testSet.name)
+        testTask.reports.junitXml.destination = new File(project.testResultsDir, "${testSet.name}-results")
     }
 }

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestTaskTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestTaskTest.groovy
@@ -34,7 +34,7 @@ class TestTaskTest extends Specification {
         then:
             def testTask = project.tasks['myTest'] as Test
             def htmlReportDir = project.file(testTask.reports.html.destination)
-            htmlReportDir == new File(project.buildDir, 'myTest')
+            htmlReportDir == new File(project.testReportDir, 'myTest')
     }
 
 
@@ -44,7 +44,7 @@ class TestTaskTest extends Specification {
 
         then:
             def testTask = project.tasks['myTest'] as Test
-            def htmlReportDir = project.file(testTask.reports.junitXml.destination)
-            htmlReportDir == new File(project.buildDir, 'myTest-results')
+            def junitXmlReportDir = project.file(testTask.reports.junitXml.destination)
+            junitXmlReportDir == new File(project.testResultsDir, 'myTest-results')
     }
 }

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestTaskTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestTaskTest.groovy
@@ -45,6 +45,6 @@ class TestTaskTest extends Specification {
         then:
             def testTask = project.tasks['myTest'] as Test
             def junitXmlReportDir = project.file(testTask.reports.junitXml.destination)
-            assert junitXmlReportDir == new File(project.testResultsDir, 'myTest')
+            junitXmlReportDir == new File(project.testResultsDir, 'myTest')
     }
 }

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestTaskTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestTaskTest.groovy
@@ -45,6 +45,6 @@ class TestTaskTest extends Specification {
         then:
             def testTask = project.tasks['myTest'] as Test
             def junitXmlReportDir = project.file(testTask.reports.junitXml.destination)
-            junitXmlReportDir == new File(project.testResultsDir, 'myTest-results')
+            assert junitXmlReportDir == new File(project.testResultsDir, 'myTest')
     }
 }


### PR DESCRIPTION
As explained in #12 (upstream), these folders and the content was all over the place.
Following the new gradle 3 convention for these folders seems reasonable.