### PR TITLE
Ensure the TestTask contains the right classes

### DIFF
--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskListener.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskListener.groovy
@@ -32,10 +32,8 @@ class TestTaskListener {
             if (testTask.metaClass.respondsTo(testTask, "getTestClassesDirs")) {
                 // Gradle 4.0+
                 // See https://docs.gradle.org/4.0/release-notes.html#detecting-test-classes-for-custom-test-tasks
-                map('testClassesDirs') {
-                    def sourceSet = (SourceSet) project.sourceSets[testSet.sourceSetName]
-                    sourceSet.output.classesDirs
-                }
+                def sourceSet = project.sourceSets[testSet.sourceSetName]
+                testTask.testClassesDirs += sourceSet.output.classesDirs
             } else {
                 map('testClassesDir') {
                     def sourceSet = (SourceSet) project.sourceSets[testSet.sourceSetName]

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskListener.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskListener.groovy
@@ -33,7 +33,7 @@ class TestTaskListener {
                 // Gradle 4.0+
                 // See https://docs.gradle.org/4.0/release-notes.html#detecting-test-classes-for-custom-test-tasks
                 def sourceSet = project.sourceSets[testSet.sourceSetName]
-                testTask.testClassesDirs += sourceSet.output.classesDirs
+                testTask.testClassesDirs = sourceSet.output.classesDirs
             } else {
                 map('testClassesDir') {
                     def sourceSet = (SourceSet) project.sourceSets[testSet.sourceSetName]

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestTaskTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestTaskTest.groovy
@@ -55,8 +55,7 @@ class TestTaskTest extends Specification {
 
         then:
             def testTask = project.tasks['myTest'] as Test
-            testTask.testClassesDirs[0] == project.sourceSets.test.output.classesDirs.singleFile
-            testTask.testClassesDirs[1] == project.sourceSets.myTest.output.classesDirs.singleFile
-            testTask.testClassesDirs.files.size() == 2
+            testTask.testClassesDirs[0] == project.sourceSets.myTest.output.classesDirs.singleFile
+            testTask.testClassesDirs.files.size() == 1
     }
 }

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestTaskTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestTaskTest.groovy
@@ -47,4 +47,16 @@ class TestTaskTest extends Specification {
             def junitXmlReportDir = project.file(testTask.reports.junitXml.destination)
             junitXmlReportDir == new File(project.testResultsDir, 'myTest')
     }
+
+
+    def "testClassesDirs should include the custom test set (in Gradle 4.0)"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            def testTask = project.tasks['myTest'] as Test
+            testTask.testClassesDirs[0] == project.sourceSets.test.output.classesDirs.singleFile
+            testTask.testClassesDirs[1] == project.sourceSets.myTest.output.classesDirs.singleFile
+            testTask.testClassesDirs.files.size() == 2
+    }
 }


### PR DESCRIPTION
I upgraded to Gradle 4.0 after 1.4.0 was released (thanks @dansanduleac!), but I found `./gradlew ete` terminated immediately, with output "No source"!! To debug this, I added:

```gradle
println ete.testClassesDirs.forEach { it -> println it }
```

and saw the following:

```
/Users/dfox/my-repo/some-sub-project/build/classes/java/test
null
```

Not sure why the `map` syntax wasn't working, but I could workaround this by adding:
```
ete.testClassesDirs += sourceSets.ete.output.classesDirs
```

This PR just contributes my fix back to mainline.  I'm no gradle expert, so all feedback/guidance welcome!

@tkrullmann, the tests pass locally (see attached [test-reports.zip](https://github.com/unbroken-dome/gradle-testsets-plugin/files/1086542/test-reports.zip)).

