### PR TITLE
Support the compileOnly and annotationProcessor configurations

### DIFF
--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/dsl/TestSet.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/dsl/TestSet.groovy
@@ -30,6 +30,9 @@ interface TestSet extends Named {
     String getCompileConfigurationName()
 
 
+    String getCompileOnlyConfigurationName()
+
+
     String getImplementationConfigurationName()
 
 

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/dsl/TestSet.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/dsl/TestSet.groovy
@@ -33,6 +33,9 @@ interface TestSet extends Named {
     String getCompileOnlyConfigurationName()
 
 
+    String getAnnotationProcessorConfigurationName()
+
+
     String getImplementationConfigurationName()
 
 

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/AbstractTestSet.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/AbstractTestSet.groovy
@@ -29,6 +29,12 @@ abstract class AbstractTestSet implements TestSet {
     }
 
 
+    @Override
+    String getCompileOnlyConfigurationName() {
+        "${name}CompileOnly"
+    }
+
+
     String getImplementationConfigurationName() {
         "${name}Implementation"
     }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/AbstractTestSet.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/AbstractTestSet.groovy
@@ -35,6 +35,12 @@ abstract class AbstractTestSet implements TestSet {
     }
 
 
+    @Override
+    String getAnnotationProcessorConfigurationName() {
+        "${name}AnnotationProcessor"
+    }
+
+
     String getImplementationConfigurationName() {
         "${name}Implementation"
     }

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/ConfigurationDependencyListener.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/ConfigurationDependencyListener.groovy
@@ -27,6 +27,7 @@ class ConfigurationDependencyListener {
     void extendsFromAdded(TestSet testSet, TestSet superTestSet) {
         addConfigurationExtension testSet.compileConfigurationName, superTestSet.compileConfigurationName
         addConfigurationExtension testSet.compileOnlyConfigurationName, superTestSet.compileOnlyConfigurationName
+        addConfigurationExtension testSet.annotationProcessorConfigurationName, superTestSet.annotationProcessorConfigurationName
         addConfigurationExtension testSet.implementationConfigurationName, superTestSet.implementationConfigurationName
         addConfigurationExtension testSet.runtimeConfigurationName, superTestSet.runtimeConfigurationName
         addConfigurationExtension testSet.runtimeOnlyConfigurationName, superTestSet.runtimeOnlyConfigurationName

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/ConfigurationDependencyListener.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/ConfigurationDependencyListener.groovy
@@ -26,6 +26,7 @@ class ConfigurationDependencyListener {
 
     void extendsFromAdded(TestSet testSet, TestSet superTestSet) {
         addConfigurationExtension testSet.compileConfigurationName, superTestSet.compileConfigurationName
+        addConfigurationExtension testSet.compileOnlyConfigurationName, superTestSet.compileOnlyConfigurationName
         addConfigurationExtension testSet.implementationConfigurationName, superTestSet.implementationConfigurationName
         addConfigurationExtension testSet.runtimeConfigurationName, superTestSet.runtimeConfigurationName
         addConfigurationExtension testSet.runtimeOnlyConfigurationName, superTestSet.runtimeOnlyConfigurationName

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/PredefinedUnitTestSet.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/PredefinedUnitTestSet.groovy
@@ -64,6 +64,16 @@ class PredefinedUnitTestSet extends AbstractTestSet {
 
 
     @Override
+    String getCompileOnlyConfigurationName() {
+        if (gradleVersion >= VersionNumber.parse('2.12')) {
+            return JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME;
+        } else {
+            return null
+        }
+    }
+
+
+    @Override
     String getImplementationConfigurationName() {
         if (gradleVersion >= VersionNumber.parse('3.4')) {
             return JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/PredefinedUnitTestSet.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/PredefinedUnitTestSet.groovy
@@ -74,6 +74,16 @@ class PredefinedUnitTestSet extends AbstractTestSet {
 
 
     @Override
+    String getAnnotationProcessorConfigurationName() {
+        if (gradleVersion >= VersionNumber.parse('4.6')) {
+            return JavaPlugin.TEST_ANNOTATION_PROCESSOR_CONFIGURATION_NAME;
+        } else {
+            return null
+        }
+    }
+
+
+    @Override
     String getImplementationConfigurationName() {
         if (gradleVersion >= VersionNumber.parse('3.4')) {
             return JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/ConfigurationDependencyTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/ConfigurationDependencyTest.groovy
@@ -32,6 +32,7 @@ class ConfigurationDependencyTest extends Specification {
         where:
             configurationBaseName | extendedConfigurationName | extendingConfigurationName
             'compile'             | 'fooCompile'              | 'barCompile'
+            'compileOnly'         | 'fooCompileOnly'          | 'barCompileOnly'
             'implementation'      | 'fooImplementation'       | 'barImplementation'
             'runtime'             | 'fooRuntime'              | 'barRuntime'
             'runtimeOnly'         | 'fooRuntimeOnly'          | 'barRuntimeOnly'

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/ConfigurationDependencyTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/ConfigurationDependencyTest.groovy
@@ -33,6 +33,7 @@ class ConfigurationDependencyTest extends Specification {
             configurationBaseName | extendedConfigurationName | extendingConfigurationName
             'compile'             | 'fooCompile'              | 'barCompile'
             'compileOnly'         | 'fooCompileOnly'          | 'barCompileOnly'
+            'annotationProcessor' | 'fooAnnotationProcessor'  | 'barAnnotationProcessor'
             'implementation'      | 'fooImplementation'       | 'barImplementation'
             'runtime'             | 'fooRuntime'              | 'barRuntime'
             'runtimeOnly'         | 'fooRuntimeOnly'          | 'barRuntimeOnly'

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/PredefinedUnitTestSetTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/PredefinedUnitTestSetTest.groovy
@@ -35,6 +35,12 @@ class PredefinedUnitTestSetTest extends Specification {
     }
 
 
+    def "Predefined 'unitTest' test set has compile-only configuration 'testCompileOnly'"() {
+        expect:
+            project.testSets['unitTest'].compileOnlyConfigurationName == 'testCompileOnly'
+    }
+
+
     def "Predefined 'unitTest' test set has implementation configuration 'testImplementation'"() {
         expect:
             project.testSets['unitTest'].implementationConfigurationName == 'testImplementation'

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/PredefinedUnitTestSetTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/PredefinedUnitTestSetTest.groovy
@@ -41,6 +41,12 @@ class PredefinedUnitTestSetTest extends Specification {
     }
 
 
+    def "Predefined 'unitTest' test set has annotation-processor configuration 'testAnnotationProcessor'"() {
+        expect:
+            project.testSets['unitTest'].annotationProcessorConfigurationName == 'testAnnotationProcessor'
+    }
+
+
     def "Predefined 'unitTest' test set has implementation configuration 'testImplementation'"() {
         expect:
             project.testSets['unitTest'].implementationConfigurationName == 'testImplementation'

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/SourceSetTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/SourceSetTest.groovy
@@ -35,6 +35,15 @@ class SourceSetTest extends Specification {
     }
 
 
+    def "New test set should have an associated compile-only configuration"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            project.configurations['myTestCompileOnly']
+    }
+
+
     def "New test set should have an associated implementation configuration"() {
         when:
             project.testSets { myTest }

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/SourceSetTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/SourceSetTest.groovy
@@ -44,6 +44,15 @@ class SourceSetTest extends Specification {
     }
 
 
+    def "New test set should have an associated annotation-processor configuration"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            project.configurations['myTestAnnotationProcessor']
+    }
+
+
     def "New test set should have an associated implementation configuration"() {
         when:
             project.testSets { myTest }

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestsPluginTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestsPluginTest.groovy
@@ -42,6 +42,15 @@ public class TestsPluginTest extends Specification {
     }
 
 
+    def "New test set's annotation-processor configuration should extend the testAnnotationProcessor configuration"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            project.configurations['myTestAnnotationProcessor'].extendsFrom == [ project.configurations['testAnnotationProcessor'] ].toSet()
+    }
+
+
     def "New test set should have an associated runtime configuration"() {
         when:
             project.testSets { myTest }

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestsPluginTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/TestsPluginTest.groovy
@@ -33,6 +33,15 @@ public class TestsPluginTest extends Specification {
     }
 
 
+    def "New test set's compile-only configuration should extend the testCompileOnly configuration"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            project.configurations['myTestCompileOnly'].extendsFrom == [ project.configurations['testCompileOnly'] ].toSet()
+    }
+
+
     def "New test set should have an associated runtime configuration"() {
         when:
             project.testSets { myTest }


### PR DESCRIPTION
My project used to use `compileOnly` for Lombok, and now uses `annotationProcessor` as well since migrating to Gradle 4.6 (otherwise you get a warning during the build). It would be nice if `gradle-testsets-plugin` supported those as well so the configuration doesn't need to be repeated for the integration tests.