### PR TITLE
Add correct configurations to IDEA classpath

### DIFF
--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/dsl/TestSet.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/dsl/TestSet.groovy
@@ -33,6 +33,9 @@ interface TestSet extends Named {
     String getCompileOnlyConfigurationName()
 
 
+    String getCompileClasspathConfigurationName()
+
+
     String getAnnotationProcessorConfigurationName()
 
 
@@ -43,6 +46,9 @@ interface TestSet extends Named {
 
 
     String getRuntimeOnlyConfigurationName()
+
+
+    String getRuntimeClasspathConfigurationName()
 
 
     String getArtifactConfigurationName()

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/AbstractTestSet.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/AbstractTestSet.groovy
@@ -36,6 +36,12 @@ abstract class AbstractTestSet implements TestSet {
 
 
     @Override
+    String getCompileClasspathConfigurationName() {
+        "${name}CompileClasspath"
+    }
+
+
+    @Override
     String getAnnotationProcessorConfigurationName() {
         "${name}AnnotationProcessor"
     }
@@ -55,6 +61,12 @@ abstract class AbstractTestSet implements TestSet {
     @Override
     String getRuntimeOnlyConfigurationName() {
         "${name}RuntimeOnly"
+    }
+
+
+    @Override
+    String getRuntimeClasspathConfigurationName() {
+        "${name}RuntimeClasspath"
     }
 
 

--- a/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/IdeaModuleListener.groovy
+++ b/src/main/groovy/org/unbrokendome/gradle/plugins/testsets/internal/IdeaModuleListener.groovy
@@ -62,8 +62,9 @@ public class IdeaModuleListener {
                 }
             }
 
-            addConfigurationToClasspath testSet.compileConfigurationName, ideaModule
-            addConfigurationToClasspath testSet.runtimeConfigurationName, ideaModule
+            addConfigurationToClasspath testSet.compileClasspathConfigurationName, ideaModule
+            addConfigurationToClasspath testSet.runtimeClasspathConfigurationName, ideaModule
+            addConfigurationToClasspath testSet.annotationProcessorConfigurationName, ideaModule
 
             applyLibraryFix ideaModule
         }

--- a/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/IdeaModuleTest.groovy
+++ b/src/test/groovy/org/unbrokendome/gradle/plugins/testsets/IdeaModuleTest.groovy
@@ -1,6 +1,7 @@
 package org.unbrokendome.gradle.plugins.testsets
 
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
@@ -26,7 +27,23 @@ class IdeaModuleTest extends Specification {
     }
 
 
+    def "Test set scopes should be added to module"() {
+        when:
+            project.testSets { myTest }
+
+        then:
+            project.idea.module.scopes.TEST.plus.containsAll testSetConfigurations()
+    }
+
+
     private Set<File> testSetSourceDirs() {
         [ project.file('src/myTest/java') ] as Set
+    }
+
+
+    private Set<Configuration> testSetConfigurations() {
+        [ project.configurations.getByName('myTestAnnotationProcessor'),
+          project.configurations.getByName('myTestCompileClasspath'),
+          project.configurations.getByName('myTestRuntimeClasspath') ] as Set
     }
 }


### PR DESCRIPTION
Without this, dependencies for the `myTestImplementation` configuration are not generated as part of the IDEA module.

This matches the behavior of the Gradle IDEA plugin:
https://github.com/gradle/gradle/blob/v5.0.0-RC1/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java#L442-L445