### PR TITLE
Use different constructor that gradle still supports

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSetContainer.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSetContainer.kt
@@ -3,10 +3,9 @@ package org.unbrokendome.gradle.plugins.testsets.dsl
 import groovy.lang.Closure
 import groovy.lang.DelegatesTo
 import org.gradle.api.Action
-import org.gradle.api.Named
 import org.gradle.api.PolymorphicDomainObjectContainer
 import org.gradle.api.Project
-import org.gradle.api.internal.AbstractPolymorphicDomainObjectContainer
+import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer
 import org.gradle.api.tasks.SourceSet
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.model.internal.core.NamedEntityInstantiator
@@ -65,10 +64,10 @@ interface TestSetContainer : PolymorphicDomainObjectContainer<TestSetBase> {
 
 private open class DefaultTestSetContainer
 @Inject constructor(project: Project, instantiator: Instantiator)
-    : AbstractPolymorphicDomainObjectContainer<TestSetBase>(
+    // Use this constructor, as they are still supporting it because 'nebula.lint' uses it
+    : DefaultPolymorphicDomainObjectContainer<TestSetBase>(
         TestSetBase::class.java,
-        instantiator,
-        Named.Namer.INSTANCE),
+        instantiator),
         TestSetContainer {
 
     private companion object {


### PR DESCRIPTION
## Before this PR

Using an internal constructor of `AbstractPolymorphicDomainObjectContainer` that has disappeared in gradle nightly, as of https://github.com/gradle/gradle/pull/7876

## After this PR

Use a different constructor from `DefaultPolymorphicDomainObjectContainer` that gradle seems to still support, because `nebula.lint` is using it and they're using nebula.lint as part of their CI pipeline.

Sadly, this is still quite brittle and need to verify if this works on any gradle 4.x.

_Edit_: verified this constructor has existed since like 2.3 (added in https://github.com/gradle/gradle/commit/18833dc8eefdf5f4fb862178cc1e118445f69d61), and definitely there in gradle 4.x:
https://github.com/gradle/gradle/blob/v4.0.0/subprojects/core/src/main/java/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainer.java#L35-L37