### PR TITLE
Fix and improvement for imports & extendsFrom

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/PredefinedUnitTestSet.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/PredefinedUnitTestSet.kt
@@ -4,8 +4,8 @@ import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.SourceSet
 
 
-internal class PredefinedUnitTestSet(sourceSet: SourceSet)
-    : AbstractTestSetBase("unitTest", sourceSet), TestSet {
+internal class PredefinedUnitTestSet(container: TestSetContainer, sourceSet: SourceSet)
+    : AbstractTestSetBase(container, "unitTest", sourceSet), TestSet {
 
     override val testTaskName: String
         get() = JavaPlugin.TEST_TASK_NAME

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestLibrary.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestLibrary.kt
@@ -16,9 +16,9 @@ interface TestLibrary : TestSetBase {
 
 
 private open class DefaultTestLibrary
-@Inject constructor(name: String, sourceSet: SourceSet)
-    : AbstractTestSetBase(name, sourceSet), TestLibrary
+@Inject constructor(container: TestSetContainer, name: String, sourceSet: SourceSet)
+    : AbstractTestSetBase(container, name, sourceSet), TestLibrary
 
 
-internal fun ObjectFactory.newTestLibrary(name: String, sourceSet: SourceSet): TestLibrary =
-        newInstance(DefaultTestLibrary::class.java, name, sourceSet)
+internal fun ObjectFactory.newTestLibrary(container: TestSetContainer, name: String, sourceSet: SourceSet): TestLibrary =
+        newInstance(DefaultTestLibrary::class.java, container, name, sourceSet)

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSet.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSet.kt
@@ -13,9 +13,9 @@ interface TestSet : TestSetBase {
 
 
 private open class DefaultTestSet
-@Inject constructor(name: String, sourceSet: SourceSet)
-    : AbstractTestSetBase(name, sourceSet), TestSet
+@Inject constructor(container: TestSetContainer, name: String, sourceSet: SourceSet)
+    : AbstractTestSetBase(container, name, sourceSet), TestSet
 
 
-internal fun ObjectFactory.newTestSet(name: String, sourceSet: SourceSet): TestSet =
-        newInstance(DefaultTestSet::class.java, name, sourceSet)
+internal fun ObjectFactory.newTestSet(container: TestSetContainer, name: String, sourceSet: SourceSet): TestSet =
+        newInstance(DefaultTestSet::class.java, container, name, sourceSet)

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSetContainer.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSetContainer.kt
@@ -49,16 +49,6 @@ interface TestSetContainer : PolymorphicDomainObjectContainer<TestSetBase> {
 
     operator fun <T : TestSetBase> String.invoke(type: KClass<T>, configureAction: T.() -> Unit = {}): T =
             maybeCreate(this, type.java).also(configureAction)
-
-
-    fun TestSetBase.imports(vararg libraryNames: String) {
-        imports(*names.map { getByName(it) as TestLibrary }.toTypedArray())
-    }
-
-
-    fun TestSetBase.extendsFrom(vararg testSetNames: String) {
-        extendsFrom(*names.map { getByName(it) }.toTypedArray())
-    }
 }
 
 
@@ -76,7 +66,9 @@ private open class DefaultTestSetContainer
     }
 
 
-    private val unitTestSet = PredefinedUnitTestSet(project.sourceSets[SourceSet.TEST_SOURCE_SET_NAME])
+    @Suppress("LeakingThis")
+    private val unitTestSet = PredefinedUnitTestSet(this,
+            project.sourceSets[SourceSet.TEST_SOURCE_SET_NAME])
             .also { add(it) }
 
 
@@ -94,10 +86,10 @@ private open class DefaultTestSetContainer
             val sourceSet = createSourceSetForTestSet(name)
             return when (type) {
                 TestSet::class.java ->
-                    project.objects.newTestSet(name, sourceSet)
+                    project.objects.newTestSet(this@DefaultTestSetContainer, name, sourceSet)
                             .apply { extendsFrom(unitTestSet) }
                 TestLibrary::class.java ->
-                    project.objects.newTestLibrary(name, sourceSet)
+                    project.objects.newTestLibrary(this@DefaultTestSetContainer, name, sourceSet)
                 else ->
                     throw IllegalArgumentException("Cannot instantiate $type")
             } as S


### PR DESCRIPTION
- `imports` and `extendsFrom` methods incorrectly iterated over all test
  sets instead the passed argument
- moved `imports`/`extendsFrom` by name into the TestSetBase; the Kotlin extension method in `TestSetContainer` may confuse the Groovy DSL (see issue #64). This also requires every `TestSet` or `TestLibrary` to maintain a reference to the container.
- `imports` and `extendsFrom` now take `Any` parameter array; this way objects
  and names can be mixed in the same call