### PR TITLE
Set test task classpath to runtimeClasspath of the sourceSet

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/TestSetsPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/TestSetsPlugin.kt
@@ -145,7 +145,7 @@ class TestSetsPlugin
 
             testSet.sourceSet.let { sourceSet ->
                 task.testClassesDirs = sourceSet.output.classesDirs
-                task.classpath = sourceSet.runtimeClasspath + task.classpath
+                task.classpath = sourceSet.runtimeClasspath
             }
         }
     }

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/TestTaskTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/TestTaskTest.kt
@@ -1,8 +1,6 @@
 package org.unbrokendome.gradle.plugins.testsets
 
-import assertk.all
 import assertk.assert
-import assertk.assertions.contains
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
@@ -10,11 +8,7 @@ import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Test
 import org.unbrokendome.gradle.plugins.testsets.dsl.testSets
-import org.unbrokendome.gradle.plugins.testsets.testutils.containsAll
 import org.unbrokendome.gradle.plugins.testsets.testutils.containsItem
-import org.unbrokendome.gradle.plugins.testsets.testutils.startsWith
-import org.unbrokendome.gradle.plugins.testsets.util.get
-import org.unbrokendome.gradle.plugins.testsets.util.sourceSets
 import org.gradle.api.tasks.testing.Test as TestTask
 
 
@@ -36,10 +30,8 @@ class TestTaskTest {
                     it.isInstanceOf(TestTask::class) {
                         it.prop("testClassesDirs", TestTask::getTestClassesDirs)
                                 .isEqualTo(testSet.sourceSet.output.classesDirs)
-                        it.prop("classpath", TestTask::getClasspath).all {
-                            startsWith(testSet.sourceSet.runtimeClasspath)
-                            containsAll(project.sourceSets["test"].output)
-                        }
+                        it.prop("classpath", TestTask::getClasspath)
+                                .isEqualTo(testSet.sourceSet.runtimeClasspath)
                     }
                 }
     }


### PR DESCRIPTION
 without accessing the current value (so it won't trigger the JavaPlugin convention)

fixes #69