### PR TITLE
test: upgrade Assertk to 0.19

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     testImplementation(kotlin("stdlib-jdk8"))
     testImplementation(kotlin("reflect"))
     testImplementation(kotlin("gradle-plugin"))
-    testImplementation("com.willowtreeapps.assertk:assertk-jvm:0.12")
+    testImplementation("com.willowtreeapps.assertk:assertk-jvm:0.19")
 
     "integrationTestImplementation"(gradleApi())
 }

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/GradleVersionsCompatibilityTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/GradleVersionsCompatibilityTest.kt
@@ -1,6 +1,6 @@
 package org.unbrokendome.gradle.plugins.testsets
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.isIn
 import assertk.assertions.isNotNull
 import assertk.assertions.prop
@@ -44,12 +44,12 @@ class GradleVersionsCompatibilityTest {
                 .forwardOutput()
                 .build()
 
-        assert(result, "result")
-                .prop("for task integrationTest") { it.task(":integrationTest") }
-                .isNotNull {
-                    it.prop("outcome", BuildTask::getOutcome)
-                            .isIn(TaskOutcome.NO_SOURCE, TaskOutcome.UP_TO_DATE)
-                }
+        assertThat(result, "result")
+            .prop("for task integrationTest") { it.task(":integrationTest") }
+            .isNotNull().let {
+                it.prop("outcome", BuildTask::getOutcome)
+                    .isIn(TaskOutcome.NO_SOURCE, TaskOutcome.UP_TO_DATE)
+            }
     }
 
 

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/ArtifactTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/ArtifactTest.kt
@@ -1,6 +1,6 @@
 package org.unbrokendome.gradle.plugins.testsets
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
@@ -32,12 +32,11 @@ class ArtifactTest {
             it.classifier = "foo-classifier"
         }
 
-        assert(project.tasks, "tasks")
+        assertThat(project.tasks, "tasks")
                 .containsItem("fooJar") {
-                    it.isInstanceOf(Jar::class.java) {
-                        it.prop("classifier", Jar::getClassifier)
-                                .isEqualTo("foo-classifier")
-                    }
+                    it.isInstanceOf(Jar::class.java)
+                        .prop("classifier", Jar::getClassifier)
+                        .isEqualTo("foo-classifier")
                 }
     }
 
@@ -51,7 +50,7 @@ class ArtifactTest {
 
         project.evaluate()
 
-        assert(project.configurations, "configurations")
+        assertThat(project.configurations, "configurations")
                 .containsItem("foo") {
                     it.prop("allArtifacts", Configuration::getAllArtifacts)
                             .hasSingleItem {

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/SourceSetTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/SourceSetTest.kt
@@ -1,7 +1,7 @@
 package org.unbrokendome.gradle.plugins.testsets
 
 import assertk.all
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.hasSize
 import assertk.assertions.prop
@@ -32,7 +32,7 @@ class SourceSetTest {
     fun `Should create a new source set for a test set`() {
         project.testSets.create("foo")
 
-        assert(project.sourceSets, "sourceSets")
+        assertThat(project.sourceSets, "sourceSets")
                 .containsItem("foo")
     }
 
@@ -43,7 +43,7 @@ class SourceSetTest {
             it.dirName = "bar"
         }
 
-        assert(project.sourceSets, "sourceSets")
+        assertThat(project.sourceSets, "sourceSets")
                 .containsItem("foo") {
                     it.prop("java", SourceSet::getJava)
                             .prop("srcDirs", SourceDirectorySet::getSrcDirs)
@@ -69,7 +69,7 @@ class SourceSetTest {
             it.dirName = "bar"
         }
 
-        assert(project.sourceSets, "sourceSets")
+        assertThat(project.sourceSets, "sourceSets")
                 .containsItem("foo") {
                     it.hasConvention<GroovySourceSet> {
                         it.prop("groovy", GroovySourceSet::getGroovy)
@@ -91,7 +91,7 @@ class SourceSetTest {
             it.dirName = "bar"
         }
 
-        assert(project.sourceSets, "sourceSets")
+        assertThat(project.sourceSets, "sourceSets")
                 .containsItem("foo") {
                     it.hasConvention<KotlinSourceSet> {
                         it.prop("kotlin") { it.kotlin }

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/TestSetConfigurationsTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/TestSetConfigurationsTest.kt
@@ -1,6 +1,6 @@
 package org.unbrokendome.gradle.plugins.testsets
 
-import assertk.assert
+import assertk.assertThat
 import org.gradle.api.Project
 import org.gradle.api.artifacts.FileCollectionDependency
 import org.gradle.testfixtures.ProjectBuilder
@@ -37,7 +37,7 @@ class TestSetConfigurationsTest {
 
         val (configurationName, superConfigurationName) = configs.split(" <- ")
 
-        assert(project.configurations, "configurations")
+        assertThat(project.configurations, "configurations")
                 .containsItem(configurationName) {
                     it.extendsFrom(superConfigurationName)
                 }
@@ -59,7 +59,7 @@ class TestSetConfigurationsTest {
 
         val (configurationName, superConfigurationName) = configs.split(" <- ")
 
-        assert(project.configurations, "configurations")
+        assertThat(project.configurations, "configurations")
                 .containsItem(configurationName) {
                     it.extendsFrom(superConfigurationName)
                 }
@@ -78,7 +78,7 @@ class TestSetConfigurationsTest {
 
         @Test
         fun `Implementation should depend on API dependencies from imported library`() {
-            assert(project.configurations, "configurations")
+            assertThat(project.configurations, "configurations")
                     .containsItem("fooImplementation") {
                         it.extendsFrom("barApi")
                     }
@@ -87,7 +87,7 @@ class TestSetConfigurationsTest {
 
         @Test
         fun `Implementation should depend on classes from imported library`() {
-            assert(project.configurations, "configurations")
+            assertThat(project.configurations, "configurations")
                     .containsItem("fooImplementation") {
                         it.containsDependency<FileCollectionDependency>("bar's output") {
                             it.files == barLibrary.sourceSet.output

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/TestSetsPluginTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/TestSetsPluginTest.kt
@@ -1,6 +1,6 @@
 package org.unbrokendome.gradle.plugins.testsets
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
@@ -22,13 +22,13 @@ class TestSetsPluginTest {
 
     @Test
     fun `should create a testSets extension`() {
-        assert(project).hasExtension<TestSetContainer>("testSets")
+        assertThat(project).hasExtension<TestSetContainer>("testSets")
     }
 
 
     @Test
     fun `should have a predefined "unitTest" test set`() {
-        assert(project.testSets, "testSets")
+        assertThat(project.testSets, "testSets")
                 .containsItem("unitTest") {
                     it.isInstanceOf(TestSet::class)
                 }

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/TestTaskTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/TestTaskTest.kt
@@ -1,6 +1,6 @@
 package org.unbrokendome.gradle.plugins.testsets
 
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
@@ -25,9 +25,9 @@ class TestTaskTest {
     fun `Should create a Test task for each test set`() {
         val testSet = project.testSets.create("fooTest")
 
-        assert(project.tasks, "tasks")
+        assertThat(project.tasks, "tasks")
                 .containsItem("fooTest") {
-                    it.isInstanceOf(TestTask::class) {
+                    it.isInstanceOf(TestTask::class).let {
                         it.prop("testClassesDirs", TestTask::getTestClassesDirs)
                                 .isEqualTo(testSet.sourceSet.output.classesDirs)
                         it.prop("classpath", TestTask::getClasspath)

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/testutils/AssertionExtensions.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/testutils/AssertionExtensions.kt
@@ -9,107 +9,122 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.internal.HasConvention
 import org.gradle.api.plugins.ExtensionAware
-import java.lang.IllegalArgumentException
 import java.lang.IllegalStateException
-import assertk.assertions.isInstanceOf as defaultIsInstanceOf
 
 
 inline fun <reified E : Any> Assert<*>.hasExtension(name: String? = null, noinline block: (Assert<E>) -> Unit = {}) {
-    if (actual !is ExtensionAware) {
-        return expected("to be ExtensionAware")
-    }
-    val extensions = (actual as ExtensionAware).extensions
+    this.given { actual ->
+        if (actual !is ExtensionAware) {
+            expected("to be ExtensionAware")
+        }
+        val extensions = actual.extensions
 
-    val extension: E = if (name != null) {
-        extensions.findByName(name)
+        val extension: E = if (name != null) {
+            extensions.findByName(name)
                 .let {
                     if (it == null) {
-                        return expected("to have an extension named \"$name\" of type ${show(E::class)}")
+                        expected("to have an extension named \"$name\" of type ${show(E::class)}")
                     }
                     if (it !is E) {
-                        return expected("to have an extension named \"$name\" of type ${show(E::class)}, but actual type was: ${show(it.javaClass)}")
+                        expected("to have an extension named \"$name\" of type ${show(E::class)}, but actual type was: ${show(it.javaClass)}")
                     }
                     it
-                }
-    } else {
-        extensions.findByType(E::class.java)
+                } as E
+        } else {
+            extensions.findByType(E::class.java)
                 .let {
                     if (it == null) {
-                        return expected("to have an extension of type ${show(E::class)}")
+                        expected("to have an extension of type ${show(E::class)}")
                     }
                     it
-                }
-    } as E
+                } as E
+        }
 
-    assert(extension, name = "extension " + (name?.let { "\"$it\""} ?: show(E::class))).all(block)
+        assertThat(extension, name = "extension " + (name?.let { "\"$it\"" } ?: show(E::class))).all(block)
+    }
 }
 
 
 inline fun <reified E : Any> Assert<*>.hasConvention(noinline block: (Assert<E>) -> Unit = {}) {
-    if (actual !is HasConvention) {
-        return expected("to have conventions")
-    }
-    val convention = (actual as HasConvention).convention
+    this.given { actual ->
+        if (actual !is HasConvention) {
+            expected("to have conventions")
+        }
+        val convention = actual.convention
 
-    val conventionObject: E =
+        val conventionObject: E =
             try {
                 convention.getPlugin(E::class.java)
             } catch (ex: IllegalStateException) {
-                return expected("to have a convention of type ${show(E::class)}")
+                expected("to have a convention of type ${show(E::class)}")
             }
 
-    assert(conventionObject, name = "convention object ${show(E::class)}").all(block)
+        assertThat(conventionObject, name = "convention object ${show(E::class)}").all(block)
+    }
 }
 
 
 
 fun <T : Any> Assert<NamedDomainObjectCollection<T>>.containsItem(name: String, block: (Assert<T>) -> Unit = {}) {
-    val item = actual.findByName(name) ?: return expected("to contain an item named \"$name\"", actual = actual.toList())
-    assert(item, name = name).all(block)
+    this.given { actual ->
+        val item = actual.findByName(name)
+            ?: expected("to contain an item named \"$name\"", actual = actual.toList())
+        assertThat(item, name = name).all(block)
+    }
 }
 
 
 fun Assert<Configuration>.extendsFrom(other: String) {
-    if (actual.extendsFrom.none { it.name == other }) {
-        return expected("to extend from another configuration ${show(other)}")
+    this.given { actual ->
+        if (actual.extendsFrom.none { it.name == other }) {
+            expected("to extend from another configuration ${show(other)}")
+        }
     }
 }
 
 
 inline fun <reified D : Dependency> Assert<Configuration>.containsDependency(description: String, noinline predicate: (D) -> Boolean) {
-    val dependencies = actual.dependencies.withType(D::class.java)
+    this.given { actual ->
+        val dependencies = actual.dependencies.withType(D::class.java)
             .matching(predicate)
-    if (dependencies.isEmpty()) {
-        return expected("to contain a dependency on $description")
+        if (dependencies.isEmpty()) {
+            expected("to contain a dependency on $description")
+        }
     }
 }
 
 
 fun <T> Assert<Iterable<T>>.hasSingleItem(block: (Assert<T>) -> Unit = {}) {
-    val item = try {
-        actual.single()
-    } catch (ex: Exception) {
-        return expected("to contain a single item")
+    this.given { actual ->
+        val item = try {
+            actual.single()
+        } catch (ex: Exception) {
+            expected("to contain a single item")
+        }
+        assertThat(item, name = "[0]").all(block)
     }
-    assert(item, name = "[0]").all(block)
 }
 
 
 fun <T> Assert<Iterable<T>>.startsWith(items: Iterable<T>) {
-    val itemsIter = items.iterator()
-    val actualIter = actual.iterator()
-    while (itemsIter.hasNext()) {
-        val item = itemsIter.next()
-        if (!actualIter.hasNext() || actualIter.next() != item) {
-            return expected("to start with ${show(items)}\n but did not contain ${show(item)}", actual = actual)
+    this.given { actual ->
+        val itemsIter = items.iterator()
+        val actualIter = actual.iterator()
+        while (itemsIter.hasNext()) {
+            val item = itemsIter.next()
+            if (!actualIter.hasNext() || actualIter.next() != item) {
+                expected("to start with ${show(items)}\n but did not contain ${show(item)}", actual = actual)
+            }
         }
     }
 }
 
 
 fun <T> Assert<Iterable<T>>.containsAll(items: Iterable<T>) {
-    val notContained = items.minus(actual)
-    if (notContained.isNotEmpty()) {
-        return expected("to contain all of ${show(items)}\n  but did not contain ${show(notContained)}", actual = actual)
+    this.given { actual ->
+        val notContained = items.minus(actual)
+        if (notContained.isNotEmpty()) {
+            expected("to contain all of ${show(items)}\n  but did not contain ${show(notContained)}", actual = actual)
+        }
     }
 }

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/testutils/AssertionExtensions.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/testutils/AssertionExtensions.kt
@@ -22,22 +22,14 @@ inline fun <reified E : Any> Assert<*>.hasExtension(name: String? = null, noinli
         val extension: E = if (name != null) {
             extensions.findByName(name)
                 .let {
-                    if (it == null) {
-                        expected("to have an extension named \"$name\" of type ${show(E::class)}")
+                    when (it) {
+                        null -> expected("to have an extension named \"$name\" of type ${show(E::class)}")
+                        !is E -> expected("to have an extension named \"$name\" of type ${show(E::class)}, but actual type was: ${show(it.javaClass)}")
+                        else -> it
                     }
-                    if (it !is E) {
-                        expected("to have an extension named \"$name\" of type ${show(E::class)}, but actual type was: ${show(it.javaClass)}")
-                    }
-                    it
-                } as E
+                }
         } else {
-            extensions.findByType(E::class.java)
-                .let {
-                    if (it == null) {
-                        expected("to have an extension of type ${show(E::class)}")
-                    }
-                    it
-                } as E
+            extensions.findByType(E::class.java) ?: expected("to have an extension of type ${show(E::class)}")
         }
 
         assertThat(extension, name = "extension " + (name?.let { "\"$it\"" } ?: show(E::class))).all(block)


### PR DESCRIPTION
Upgrade Assertk to 0.19 in order to avoid mixing Kotlin 1.2 and 1.3 jars.