### PR TITLE
Kotlin DSL fix in TestSetContainer

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSetContainer.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSetContainer.kt
@@ -24,7 +24,7 @@ interface TestSetContainer : PolymorphicDomainObjectContainer<TestSetBase> {
             create(name, TestSet::class.java)
 
     @JvmDefault
-    fun create(name: String, configureAction: Action<TestSet>): TestSet =
+    fun createTestSet(name: String, configureAction: Action<TestSet>): TestSet =
         create(name, TestSet::class.java, configureAction)
 
     @JvmDefault


### PR DESCRIPTION
Rename `create` to `createTestSet` to avoid an overload resolution ambiguity error in Kotlin DSL