### PR TITLE
Modify Test task's environment and system properties from TestSet

### DIFF
--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/AbstractGradleIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/AbstractGradleIntegrationTest.kt
@@ -1,0 +1,47 @@
+package org.unbrokendome.gradle.plugins.testsets
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInfo
+import java.io.File
+import java.nio.file.Files
+
+
+abstract class AbstractGradleIntegrationTest {
+
+    protected lateinit var projectDir: File
+
+    protected val buildDir: File
+        get() = projectDir.resolve("build")
+
+
+    @BeforeEach
+    fun setupProject(testInfo: TestInfo) {
+        projectDir = Files.createTempDirectory("gradle").toFile()
+        val projectName = projectDir.name
+
+        // Always create a settings file, otherwise Gradle searches up the directory hierarchy
+        // (and might actually find another file)
+        directory(projectDir) {
+            file("settings.gradle", contents = """ 
+                rootProject.name = '$projectName'
+            """)
+        }
+    }
+
+
+    @AfterEach
+    fun cleanupProject() {
+        projectDir.deleteRecursively()
+    }
+
+
+    protected fun runGradle(vararg args: String) =
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withDebug(true)
+            .withArguments(listOf(*args) + "--stacktrace")
+            .build()
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/DirectoryBuilder.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/DirectoryBuilder.kt
@@ -1,0 +1,55 @@
+package org.unbrokendome.gradle.plugins.testsets
+
+import java.io.File
+import java.nio.charset.Charset
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardOpenOption
+
+
+class DirectoryBuilder(private val path: Path) {
+
+    init {
+        if (!Files.exists(path)) {
+            Files.createDirectories(path)
+        }
+        check(Files.isDirectory(path)) { "Directory \"$path\" exists and is not a directory" }
+    }
+
+    fun directory(name: String, spec: DirectoryBuilder.() -> Unit) {
+        val subPath = this.path.resolve(name)
+        if (!Files.exists(subPath)) {
+            Files.createDirectories(subPath)
+        }
+        check(Files.isDirectory(subPath)) { "Directory \"$subPath\" exists and is not a directory" }
+        DirectoryBuilder(subPath).let(spec)
+    }
+
+    fun file(name: String, contents: String, append: Boolean = false, charset: Charset = Charsets.UTF_8) {
+        val filePath = this.path.resolve(name)
+
+        val options = arrayOf(
+            StandardOpenOption.CREATE,
+            StandardOpenOption.WRITE,
+            if (append) StandardOpenOption.APPEND else StandardOpenOption.TRUNCATE_EXISTING
+        )
+
+        Files.newBufferedWriter(filePath, charset, *options)
+            .use { writer ->
+                writer.append(contents.trimIndent())
+            }
+    }
+}
+
+
+fun directory(basePath: Path, spec: DirectoryBuilder.() -> Unit) =
+    DirectoryBuilder(basePath).let(spec)
+
+
+fun directory(basePath: File, spec: DirectoryBuilder.() -> Unit) =
+    directory(basePath.toPath(), spec)
+
+
+fun directory(basePath: String, spec: DirectoryBuilder.() -> Unit) =
+    directory(Paths.get(basePath), spec)

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/EnvironmentVariablesIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/EnvironmentVariablesIntegrationTest.kt
@@ -1,0 +1,78 @@
+package org.unbrokendome.gradle.plugins.testsets
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.prop
+import org.gradle.testkit.runner.BuildTask
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+
+class EnvironmentVariablesIntegrationTest : AbstractGradleIntegrationTest() {
+
+    @ParameterizedTest
+    @ValueSource(strings = [
+        """environment = mapOf("TESTVAR" to "TESTVALUE")""",
+        """environment(mapOf("TESTVAR" to "TESTVALUE"))""",
+        """environment("TESTVAR", "TESTVALUE")"""
+    ])
+    fun `should pass environment variable to test execution`(envVarStatement: String) {
+
+        directory(projectDir) {
+            file("build.gradle.kts", """
+                plugins {
+                    `java`
+                    id("org.unbroken-dome.test-sets")
+                }
+                
+                repositories {
+                    jcenter()
+                }
+                
+                testSets {
+                    createTestSet("integrationTest") {
+                        $envVarStatement
+                    }
+                }
+                
+                dependencies {
+                    testImplementation("org.junit.jupiter:junit-jupiter-api:5.5.2")
+                    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.5.2")
+                }
+                
+                tasks.withType<Test> {
+                    useJUnitPlatform()
+                }
+            """)
+
+            directory("src/integrationTest/java") {
+                file("EnvironmentTest.java", """
+                    import static org.junit.jupiter.api.Assertions.*;
+                    import org.junit.jupiter.api.Test;
+                    
+                    class EnvironmentTest {
+                        
+                        @Test
+                        void shouldHaveEnvironmentAvailable() {
+                            String value = System.getenv("TESTVAR");
+                            assertEquals("TESTVALUE", value);
+                        }
+                    }
+                """)
+            }
+
+            val result = runGradle("integrationTest")
+
+            assertThat(result, "result")
+                .prop("for task integrationTest") { it.task(":integrationTest") }
+                .isNotNull()
+                .prop("outcome", BuildTask::getOutcome)
+                .isEqualTo(TaskOutcome.SUCCESS)
+        }
+
+    }
+
+
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/SystemPropertiesIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/SystemPropertiesIntegrationTest.kt
@@ -1,0 +1,78 @@
+package org.unbrokendome.gradle.plugins.testsets
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.prop
+import org.gradle.testkit.runner.BuildTask
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+
+class SystemPropertiesIntegrationTest : AbstractGradleIntegrationTest() {
+
+    @ParameterizedTest
+    @ValueSource(strings = [
+        """systemProperties = mapOf("TESTVAR" to "TESTVALUE")""",
+        """systemProperties(mapOf("TESTVAR" to "TESTVALUE"))""",
+        """systemProperty("TESTVAR", "TESTVALUE")"""
+    ])
+    fun `should pass system property to test execution`(sysPropStatement: String) {
+
+        directory(projectDir) {
+            file("build.gradle.kts", """
+                plugins {
+                    `java`
+                    id("org.unbroken-dome.test-sets")
+                }
+                
+                repositories {
+                    jcenter()
+                }
+                
+                testSets {
+                    createTestSet("integrationTest") {
+                        $sysPropStatement
+                    }
+                }
+                
+                dependencies {
+                    testImplementation("org.junit.jupiter:junit-jupiter-api:5.5.2")
+                    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.5.2")
+                }
+                
+                tasks.withType<Test> {
+                    useJUnitPlatform()
+                }
+            """)
+
+            directory("src/integrationTest/java") {
+                file("EnvironmentTest.java", """
+                    import static org.junit.jupiter.api.Assertions.*;
+                    import org.junit.jupiter.api.Test;
+                    
+                    class EnvironmentTest {
+                        
+                        @Test
+                        void shouldHaveEnvironmentAvailable() {
+                            String value = System.getProperty("TESTVAR");
+                            assertEquals("TESTVALUE", value);
+                        }
+                    }
+                """)
+            }
+
+            val result = runGradle("integrationTest")
+
+            assertThat(result, "result")
+                .prop("for task integrationTest") { it.task(":integrationTest") }
+                .isNotNull()
+                .prop("outcome", BuildTask::getOutcome)
+                .isEqualTo(TaskOutcome.SUCCESS)
+        }
+
+    }
+
+
+}

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/TestSetsPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/TestSetsPlugin.kt
@@ -17,9 +17,12 @@ import org.gradle.plugins.ide.idea.IdeaPlugin
 import org.gradle.testing.jacoco.plugins.JacocoPlugin
 import org.gradle.testing.jacoco.tasks.JacocoReport
 import org.unbrokendome.gradle.plugins.testsets.dsl.*
+import org.unbrokendome.gradle.plugins.testsets.internal.*
 import org.unbrokendome.gradle.plugins.testsets.internal.ConfigurationObserver
 import org.unbrokendome.gradle.plugins.testsets.internal.IdeaModuleObserver
 import org.unbrokendome.gradle.plugins.testsets.internal.SourceSetObserver
+import org.unbrokendome.gradle.plugins.testsets.internal.TestTaskEnvironmentObserver
+import org.unbrokendome.gradle.plugins.testsets.internal.TestTaskSystemPropertiesObserver
 import org.unbrokendome.gradle.plugins.testsets.util.extension
 import org.unbrokendome.gradle.plugins.testsets.util.get
 import org.unbrokendome.gradle.plugins.testsets.util.registerOrConfigure
@@ -42,7 +45,9 @@ class TestSetsPlugin
 
         val observers = listOf(
             SourceSetObserver(project),
-            ConfigurationObserver(project)
+            ConfigurationObserver(project),
+            TestTaskEnvironmentObserver(project.tasks),
+            TestTaskSystemPropertiesObserver(project.tasks)
         )
 
         testSets.all { testSet ->
@@ -157,6 +162,8 @@ class TestSetsPlugin
             testSet.sourceSet.let { sourceSet ->
                 task.testClassesDirs = sourceSet.output.classesDirs
                 task.classpath = sourceSet.runtimeClasspath
+                task.environment = testSet.environment
+                task.systemProperties = testSet.systemProperties
             }
         }
     }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/PredefinedUnitTestSet.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/PredefinedUnitTestSet.kt
@@ -11,8 +11,24 @@ internal class PredefinedUnitTestSet(container: TestSetContainer, sourceSet: Sou
     override val testTaskName: String
         get() = JavaPlugin.TEST_TASK_NAME
 
+
     override val jarTaskName: String
         get() = "testJar"
 
+
     override var classifier: String = "tests"
+
+
+    override var environment: Map<String, Any> = mutableMapOf()
+        set(value) {
+            field = value
+            notifyObservers { it.environmentVariablesChanged(this, value) }
+        }
+
+
+    override var systemProperties: Map<String, Any?> = mutableMapOf()
+        set(value) {
+            field = value
+            notifyObservers { it.systemPropertiesChanged(this, value) }
+        }
 }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSet.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSet.kt
@@ -18,12 +18,94 @@ interface TestSet : TestSetBase {
      */
     val jacocoReportTaskName: String
         get() = NamingConventions.jacocoReportTaskName(testTaskName)
+
+    /**
+     * The environment for the test process.
+     *
+     * This will be an empty [Map] if there are no environment variables.
+     *
+     * @see org.gradle.api.tasks.testing.Test.getEnvironment
+     * @see org.gradle.api.tasks.testing.Test.setEnvironment
+     */
+    var environment: Map<String, Any>
+
+    /**
+     * Adds some environment variables to the environment for the test process.
+     *
+     * @param environmentVariables the environment variables
+     *
+     * @see org.gradle.api.tasks.testing.Test.environment
+     */
+    @JvmDefault
+    fun environment(environmentVariables: Map<String, Any>) {
+        this.environment += environmentVariables
+    }
+
+    /**
+     * Adds an environment variable to the environment for the test process.
+     *
+     * @param name the name of the variable
+     * @param value the value for the variable
+     *
+     * @see org.gradle.api.tasks.testing.Test.environment
+     */
+    @JvmDefault
+    fun environment(name: String, value: Any) {
+        this.environment += name to value
+    }
+
+    /**
+     * The system properties that will be used for the test process.
+     *
+     * This will be an empty [Map] if there are no system properties.
+     *
+     * @see org.gradle.api.tasks.testing.Test.getSystemProperties
+     * @see org.gradle.api.tasks.testing.Test.setSystemProperties
+     */
+    var systemProperties: Map<String, Any?>
+
+    /**
+     * Adds some system properties to use for the process.
+     *
+     * @param properties the system properties
+     * @see org.gradle.api.tasks.testing.Test.systemProperties
+     */
+    @JvmDefault
+    fun systemProperties(properties: Map<String, *>) {
+        this.systemProperties += properties
+    }
+
+    /**
+     * Adds a system property to use for the process.
+     *
+     * @param name The name of the property
+     * @param value The value for the property. May be null.
+     * @return this
+     */
+    @JvmDefault
+    fun systemProperty(name: String, value: Any?) {
+        this.systemProperties += name to value
+    }
 }
 
 
 private open class DefaultTestSet
 @Inject constructor(container: TestSetContainer, name: String, sourceSet: SourceSet)
-    : AbstractTestSetBase(container, name, sourceSet), TestSet
+    : AbstractTestSetBase(container, name, sourceSet), TestSet {
+
+    override var environment: Map<String, Any> = mutableMapOf()
+        set(value) {
+            field = value
+            notifyObservers { it.environmentVariablesChanged(this, value) }
+        }
+
+
+    override var systemProperties: Map<String, Any?> = mutableMapOf()
+        set(value) {
+            field = value
+            notifyObservers { it.systemPropertiesChanged(this, value) }
+        }
+}
 
 
 internal fun ObjectFactory.newTestSet(container: TestSetContainer, name: String, sourceSet: SourceSet): TestSet =

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSetBase.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSetBase.kt
@@ -149,6 +149,10 @@ internal interface TestSetObserver {
     fun importAdded(testSet: TestSetBase, added: TestLibrary) {}
 
     fun importRemoved(testSet: TestSetBase, removed: TestLibrary) {}
+
+    fun environmentVariablesChanged(testSet: TestSetBase, newEnvironment: Map<String, Any?>) {}
+
+    fun systemPropertiesChanged(testSet: TestSetBase, newProperties: Map<String, Any?>) {}
 }
 
 
@@ -258,7 +262,7 @@ internal abstract class AbstractTestSetBase(
     }
 
 
-    private fun notifyObservers(action: (TestSetObserver) -> Unit) {
+    protected fun notifyObservers(action: (TestSetObserver) -> Unit) {
         for (observer in observers) {
             action(observer)
         }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskEnvironmentObserver.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskEnvironmentObserver.kt
@@ -1,0 +1,20 @@
+package org.unbrokendome.gradle.plugins.testsets.internal
+
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.testing.Test
+import org.unbrokendome.gradle.plugins.testsets.dsl.TestSet
+import org.unbrokendome.gradle.plugins.testsets.dsl.TestSetBase
+import org.unbrokendome.gradle.plugins.testsets.dsl.TestSetObserver
+
+
+internal class TestTaskEnvironmentObserver(
+    private val tasks: TaskContainer
+) : TestSetObserver {
+
+    override fun environmentVariablesChanged(testSet: TestSetBase, newEnvironment: Map<String, Any?>) {
+        val testTaskName = (testSet as TestSet).testTaskName
+        (tasks.findByName(testTaskName) as? Test?)?.let { task ->
+            task.environment = newEnvironment
+        }
+    }
+}

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskSystemPropertiesObserver.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskSystemPropertiesObserver.kt
@@ -1,0 +1,20 @@
+package org.unbrokendome.gradle.plugins.testsets.internal
+
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.testing.Test
+import org.unbrokendome.gradle.plugins.testsets.dsl.TestSet
+import org.unbrokendome.gradle.plugins.testsets.dsl.TestSetBase
+import org.unbrokendome.gradle.plugins.testsets.dsl.TestSetObserver
+
+
+internal class TestTaskSystemPropertiesObserver(
+    private val tasks: TaskContainer
+) : TestSetObserver {
+
+    override fun systemPropertiesChanged(testSet: TestSetBase, newProperties: Map<String, Any?>) {
+        val testTaskName = (testSet as TestSet).testTaskName
+        (tasks.findByName(testTaskName) as? Test?)?.let { task ->
+            task.systemProperties = newProperties
+        }
+    }
+}

--- a/src/test/kotlin/EnvironmentTest.java
+++ b/src/test/kotlin/EnvironmentTest.java
@@ -1,0 +1,11 @@
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+
+class EnvironmentTest {
+
+    @Test
+    void shouldHaveEnvironmentAvailable() {
+        String value = System.getenv("TESTVAR");
+        assertEquals("TESTVALUE", value);
+    }
+}


### PR DESCRIPTION
This allows us to modify the corresponding properties of the Test task directly from the TestSet. This feature was already available in 1.x.