### PR TITLE
Test sets inherit existing environemnt

### DIFF
--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/EnvironmentVariablesIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/EnvironmentVariablesIntegrationTest.kt
@@ -4,7 +4,6 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.prop
-import org.gradle.internal.file.DefaultFileMetadata.file
 import org.gradle.testkit.runner.BuildTask
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
@@ -14,21 +13,6 @@ import org.junit.jupiter.params.provider.ValueSource
 
 
 class EnvironmentVariablesIntegrationTest : AbstractGradleIntegrationTest() {
-    companion object {
-        const val TEST_FILE = """
-                    import static org.junit.jupiter.api.Assertions.*;
-                    import org.junit.jupiter.api.Test;
-                    
-                    class EnvironmentTest {
-                        
-                        @Test
-                        void shouldHaveEnvironmentAvailable() {
-                            String value = System.getenv("TESTVAR");
-                            assertEquals("TESTVALUE", value);
-                        }
-                    }
-                """
-    }
 
     @ParameterizedTest
     @ValueSource(strings = [
@@ -66,7 +50,19 @@ class EnvironmentVariablesIntegrationTest : AbstractGradleIntegrationTest() {
             """)
 
             directory("src/integrationTest/java") {
-                file("EnvironmentTest.java", TEST_FILE)
+                file("EnvironmentTest.java", """
+                            import static org.junit.jupiter.api.Assertions.*;
+                            import org.junit.jupiter.api.Test;
+                            
+                            class EnvironmentTest {
+                                
+                                @Test
+                                void shouldHaveEnvironmentAvailable() {
+                                    String value = System.getenv("TESTVAR");
+                                    assertEquals("TESTVALUE", value);
+                                }
+                            }
+                        """)
             }
 
             val result = runGradle("integrationTest")
@@ -93,7 +89,9 @@ class EnvironmentVariablesIntegrationTest : AbstractGradleIntegrationTest() {
                 }
                 
                 testSets {
-                    createTestSet("integrationTest") { }
+                    createTestSet("integrationTest") { 
+                        environment("TESTVAR2", "TESTVALUE")
+                    }
                 }
                 
                 dependencies {
@@ -107,7 +105,21 @@ class EnvironmentVariablesIntegrationTest : AbstractGradleIntegrationTest() {
             """)
 
             directory("src/integrationTest/java") {
-                file("EnvironmentTest.java", TEST_FILE)
+                file("EnvironmentTest.java", """
+                            import static org.junit.jupiter.api.Assertions.*;
+                            import org.junit.jupiter.api.Test;
+                            
+                            class EnvironmentTest {
+                                
+                                @Test
+                                void shouldHaveEnvironmentAvailable() {
+                                    String value = System.getenv("TESTVAR");
+                                    assertEquals("TESTVALUE", value);
+                                    value = System.getenv("TESTVAR2");
+                                    assertEquals("TESTVALUE", value);
+                                }
+                            }
+                        """)
             }
 
             val result = GradleRunner.create()

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/EnvironmentVariablesIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/EnvironmentVariablesIntegrationTest.kt
@@ -51,18 +51,18 @@ class EnvironmentVariablesIntegrationTest : AbstractGradleIntegrationTest() {
 
             directory("src/integrationTest/java") {
                 file("EnvironmentTest.java", """
-                            import static org.junit.jupiter.api.Assertions.*;
-                            import org.junit.jupiter.api.Test;
-                            
-                            class EnvironmentTest {
-                                
-                                @Test
-                                void shouldHaveEnvironmentAvailable() {
-                                    String value = System.getenv("TESTVAR");
-                                    assertEquals("TESTVALUE", value);
-                                }
-                            }
-                        """)
+                    import static org.junit.jupiter.api.Assertions.*;
+                    import org.junit.jupiter.api.Test;
+                    
+                    class EnvironmentTest {
+                        
+                        @Test
+                        void shouldHaveEnvironmentAvailable() {
+                            String value = System.getenv("TESTVAR");
+                            assertEquals("TESTVALUE", value);
+                        }
+                    }
+                """)
             }
 
             val result = runGradle("integrationTest")
@@ -106,20 +106,20 @@ class EnvironmentVariablesIntegrationTest : AbstractGradleIntegrationTest() {
 
             directory("src/integrationTest/java") {
                 file("EnvironmentTest.java", """
-                            import static org.junit.jupiter.api.Assertions.*;
-                            import org.junit.jupiter.api.Test;
-                            
-                            class EnvironmentTest {
-                                
-                                @Test
-                                void shouldHaveEnvironmentAvailable() {
-                                    String value = System.getenv("TESTVAR");
-                                    assertEquals("TESTVALUE", value);
-                                    value = System.getenv("TESTVAR2");
-                                    assertEquals("TESTVALUE", value);
-                                }
-                            }
-                        """)
+                    import static org.junit.jupiter.api.Assertions.*;
+                    import org.junit.jupiter.api.Test;
+                    
+                    class EnvironmentTest {
+                        
+                        @Test
+                        void shouldHaveEnvironmentAvailable() {
+                            String value = System.getenv("TESTVAR");
+                            assertEquals("TESTVALUE", value);
+                            value = System.getenv("TESTVAR2");
+                            assertEquals("TESTVALUE", value);
+                        }
+                    }
+                """)
             }
 
             val result = GradleRunner.create()

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/EnvironmentVariablesIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/EnvironmentVariablesIntegrationTest.kt
@@ -4,13 +4,31 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.prop
+import org.gradle.internal.file.DefaultFileMetadata.file
 import org.gradle.testkit.runner.BuildTask
+import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 
 class EnvironmentVariablesIntegrationTest : AbstractGradleIntegrationTest() {
+    companion object {
+        const val TEST_FILE = """
+                    import static org.junit.jupiter.api.Assertions.*;
+                    import org.junit.jupiter.api.Test;
+                    
+                    class EnvironmentTest {
+                        
+                        @Test
+                        void shouldHaveEnvironmentAvailable() {
+                            String value = System.getenv("TESTVAR");
+                            assertEquals("TESTVALUE", value);
+                        }
+                    }
+                """
+    }
 
     @ParameterizedTest
     @ValueSource(strings = [
@@ -48,19 +66,7 @@ class EnvironmentVariablesIntegrationTest : AbstractGradleIntegrationTest() {
             """)
 
             directory("src/integrationTest/java") {
-                file("EnvironmentTest.java", """
-                    import static org.junit.jupiter.api.Assertions.*;
-                    import org.junit.jupiter.api.Test;
-                    
-                    class EnvironmentTest {
-                        
-                        @Test
-                        void shouldHaveEnvironmentAvailable() {
-                            String value = System.getenv("TESTVAR");
-                            assertEquals("TESTVALUE", value);
-                        }
-                    }
-                """)
+                file("EnvironmentTest.java", TEST_FILE)
             }
 
             val result = runGradle("integrationTest")
@@ -71,7 +77,52 @@ class EnvironmentVariablesIntegrationTest : AbstractGradleIntegrationTest() {
                 .prop("outcome", BuildTask::getOutcome)
                 .isEqualTo(TaskOutcome.SUCCESS)
         }
+    }
 
+    @Test
+    fun `should inherit existing environment variables`() {
+        directory(projectDir) {
+            file("build.gradle.kts", """
+                plugins {
+                    `java`
+                    id("org.unbroken-dome.test-sets")
+                }
+                
+                repositories {
+                    jcenter()
+                }
+                
+                testSets {
+                    createTestSet("integrationTest") { }
+                }
+                
+                dependencies {
+                    testImplementation("org.junit.jupiter:junit-jupiter-api:5.5.2")
+                    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.5.2")
+                }
+                
+                tasks.withType<Test> {
+                    useJUnitPlatform()
+                }
+            """)
+
+            directory("src/integrationTest/java") {
+                file("EnvironmentTest.java", TEST_FILE)
+            }
+
+            val result = GradleRunner.create()
+                    .withProjectDir(projectDir)
+                    .withPluginClasspath()
+                    .withArguments("integrationTest",  "-s")
+                    .withEnvironment(mapOf("TESTVAR" to "TESTVALUE"))
+                    .build()
+
+            assertThat(result, "result")
+                    .prop("for task integrationTest") { it.task(":integrationTest") }
+                    .isNotNull()
+                    .prop("outcome", BuildTask::getOutcome)
+                    .isEqualTo(TaskOutcome.SUCCESS)
+        }
     }
 
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/TestSetsPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/TestSetsPlugin.kt
@@ -162,7 +162,7 @@ class TestSetsPlugin
             testSet.sourceSet.let { sourceSet ->
                 task.testClassesDirs = sourceSet.output.classesDirs
                 task.classpath = sourceSet.runtimeClasspath
-                task.environment = testSet.environment
+                task.environment(testSet.environment)
                 task.systemProperties = testSet.systemProperties
             }
         }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskEnvironmentObserver.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/internal/TestTaskEnvironmentObserver.kt
@@ -14,7 +14,7 @@ internal class TestTaskEnvironmentObserver(
     override fun environmentVariablesChanged(testSet: TestSetBase, newEnvironment: Map<String, Any?>) {
         val testTaskName = (testSet as TestSet).testTaskName
         (tasks.findByName(testTaskName) as? Test?)?.let { task ->
-            task.environment = newEnvironment
+            task.environment(newEnvironment)
         }
     }
 }


### PR DESCRIPTION
## Before this PR
There was a regression in 2.2.0 that caused test sets to no longer inherit system environment variables.

## After this PR
We correctly inherit all existing environment variables

## Possible downsides?
N/A