### PR TITLE
Make plugin compatible with Gradle 6

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSetContainer.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSetContainer.kt
@@ -126,10 +126,10 @@ private open class DefaultTestSetContainer
     private fun createSourceSetForTestSet(name: String): SourceSet =
             project.sourceSets.create(NamingConventions.sourceSetName(name))
                     .also { sourceSet ->
-                        sourceSet.compileClasspath = project.layout.configurableFiles(
+                        sourceSet.compileClasspath = project.files(
                                 project.sourceSets["main"].output,
                                 project.configurations[sourceSet.compileClasspathConfigurationName])
-                        sourceSet.runtimeClasspath = project.layout.configurableFiles(
+                        sourceSet.runtimeClasspath = project.files(
                                 sourceSet.output,
                                 project.sourceSets["main"].output,
                                 project.configurations[sourceSet.runtimeClasspathConfigurationName])


### PR DESCRIPTION
I've been getting a warning from Gradle 5.6.4 that this plugin uses a deprecated method that will cause it to be incompatible with Gradle 6.  I've followed the suggestion from the deprecation annotation to switch to ObjectFactory.fileCollection().