### PR TITLE
extend existing system properties

### DIFF
--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/SystemPropertiesIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/SystemPropertiesIntegrationTest.kt
@@ -6,6 +6,7 @@ import assertk.assertions.isNotNull
 import assertk.assertions.prop
 import org.gradle.testkit.runner.BuildTask
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
@@ -48,14 +49,14 @@ class SystemPropertiesIntegrationTest : AbstractGradleIntegrationTest() {
             """)
 
             directory("src/integrationTest/java") {
-                file("EnvironmentTest.java", """
+                file("SystemPropertiesTest.java", """
                     import static org.junit.jupiter.api.Assertions.*;
                     import org.junit.jupiter.api.Test;
                     
-                    class EnvironmentTest {
+                    class SystemPropertiesTest {
                         
                         @Test
-                        void shouldHaveEnvironmentAvailable() {
+                        void shouldHaveSystemPropertiesAvailable() {
                             String value = System.getProperty("TESTVAR");
                             assertEquals("TESTVALUE", value);
                         }
@@ -74,5 +75,62 @@ class SystemPropertiesIntegrationTest : AbstractGradleIntegrationTest() {
 
     }
 
+    @Test
+    fun `should inherit existing system property variables`() {
+        directory(projectDir) {
+            file("build.gradle.kts", """
+                plugins {
+                    `java`
+                    id("org.unbroken-dome.test-sets")
+                }
+                
+                repositories {
+                    jcenter()
+                }
+                
+                testSets {
+                    createTestSet("integrationTest") { 
+                        systemProperty("TESTVAR", "TESTVALUE")
+                    }
+                }
+                
+                dependencies {
+                    testImplementation("org.junit.jupiter:junit-jupiter-api:5.5.2")
+                    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.5.2")
+                }
+                
+                tasks.withType<Test> {
+                    useJUnitPlatform()
+                    jvmArgs("-DTESTVAR2=TESTVALUE2")
+                }
+            """)
+
+            directory("src/integrationTest/java") {
+                file("SystemPropertiesTest.java", """
+                    import static org.junit.jupiter.api.Assertions.*;
+                    import org.junit.jupiter.api.Test;
+                    
+                    class SystemPropertiesTest {
+                        
+                        @Test
+                        void shouldHaveSystemPropertiesAvailable() {
+                            String value = System.getProperty("TESTVAR");
+                            assertEquals("TESTVALUE", value);
+                            String value2 = System.getProperty("TESTVAR2");
+                            assertEquals("TESTVALUE2", value2);
+                        }
+                    }
+                """)
+            }
+
+            val result = runGradle("integrationTest")
+
+            assertThat(result, "result")
+                    .prop("for task integrationTest") { it.task(":integrationTest") }
+                    .isNotNull()
+                    .prop("outcome", BuildTask::getOutcome)
+                    .isEqualTo(TaskOutcome.SUCCESS)
+        }
+    }
 
 }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/TestSetsPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/TestSetsPlugin.kt
@@ -163,7 +163,7 @@ class TestSetsPlugin
                 task.testClassesDirs = sourceSet.output.classesDirs
                 task.classpath = sourceSet.runtimeClasspath
                 task.environment(testSet.environment)
-                task.systemProperties = testSet.systemProperties
+                task.systemProperties(testSet.systemProperties)
             }
         }
     }


### PR DESCRIPTION
As it was done on https://github.com/unbroken-dome/gradle-testsets-plugin/pull/89 , it would be preferable to extend the system properties.