### PR TITLE
Remove usage of deprecated APIs to run with Gradle 7

### DIFF
--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/GradleVersionsCompatibilityTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/GradleVersionsCompatibilityTest.kt
@@ -18,7 +18,7 @@ class GradleVersionsCompatibilityTest : AbstractGradleIntegrationTest() {
 
     abstract inner class AbstractVersionsCompatibilityTest {
 
-        @ValueSource(strings = ["5.1.1", "5.6.2", "6.0", "6.0.1"])
+        @ValueSource(strings = ["5.1.1", "5.6.2", "6.0", "6.0.1", "7.0-rc-2"])
         @ParameterizedTest(name = "Gradle {0}")
         @DisplayName("Should work in Gradle version")
         fun shouldWorkInGradleVersion(gradleVersion: String) {

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/GradleVersionsCompatibilityTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/GradleVersionsCompatibilityTest.kt
@@ -18,7 +18,7 @@ class GradleVersionsCompatibilityTest : AbstractGradleIntegrationTest() {
 
     abstract inner class AbstractVersionsCompatibilityTest {
 
-        @ValueSource(strings = ["5.1.1", "5.6.2", "6.0", "6.0.1", "7.0-rc-2"])
+        @ValueSource(strings = ["5.1.1", "5.6.2", "6.0", "6.0.1", "7.0"])
         @ParameterizedTest(name = "Gradle {0}")
         @DisplayName("Should work in Gradle version")
         fun shouldWorkInGradleVersion(gradleVersion: String) {

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSetBase.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSetBase.kt
@@ -67,13 +67,6 @@ interface TestSetBase : Named {
     var classifier: String
 
     /**
-     * The name of the configuration containing the compile dependencies for this test set.
-     */
-    @Suppress("deprecation")
-    val compileConfigurationName: String
-        get() = sourceSet.compileConfigurationName
-
-    /**
      * The name of the configuration containing the compile-only dependencies for this test set.
      */
     val compileOnlyConfigurationName: String
@@ -96,13 +89,6 @@ interface TestSetBase : Named {
      */
     val implementationConfigurationName: String
         get() = sourceSet.implementationConfigurationName
-
-    /**
-     * The name of the configuration containing the runtime dependencies for this test set.
-     */
-    @Suppress("deprecation")
-    val runtimeConfigurationName: String
-        get() = sourceSet.runtimeConfigurationName
 
     /**
      * The name of the configuration containing the runtime-only dependencies for this test set.

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/internal/ConfigurationObserver.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/internal/ConfigurationObserver.kt
@@ -12,11 +12,11 @@ internal class ConfigurationObserver(
 
     private companion object {
         val inheritedConfigurationNames: List<(TestSetBase) -> String> = listOf(
-                TestSetBase::compileConfigurationName,
+                TestSetBase::compileClasspathConfigurationName,
                 TestSetBase::compileOnlyConfigurationName,
                 TestSetBase::annotationProcessorConfigurationName,
                 TestSetBase::implementationConfigurationName,
-                TestSetBase::runtimeConfigurationName,
+                TestSetBase::runtimeClasspathConfigurationName,
                 TestSetBase::runtimeOnlyConfigurationName)
     }
 

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/TestSetConfigurationsTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/testsets/TestSetConfigurationsTest.kt
@@ -27,11 +27,11 @@ class TestSetConfigurationsTest {
     @ParameterizedTest
     @ValueSource(
         strings = [
-            "myTestCompile <- testCompile",
+            "myTestCompileClasspath <- testCompileClasspath",
             "myTestCompileOnly <- testCompileOnly",
             "myTestAnnotationProcessor <- testAnnotationProcessor",
             "myTestImplementation <- testImplementation",
-            "myTestRuntime <- testRuntime",
+            "myTestRuntimeClasspath <- testRuntimeClasspath",
             "myTestRuntimeOnly <- testRuntimeOnly"]
     )
     fun `New test set's configurations should extend the built-in test configurations`(configs: String) {
@@ -48,11 +48,11 @@ class TestSetConfigurationsTest {
     @ParameterizedTest
     @ValueSource(
         strings = [
-            "fooCompile <- barCompile",
+            "fooCompileClasspath <- barCompileClasspath",
             "fooCompileOnly <- barCompileOnly",
             "fooAnnotationProcessor <- barAnnotationProcessor",
             "fooImplementation <- barImplementation",
-            "fooRuntime <- barRuntime",
+            "fooRuntimeClasspath <- barRuntimeClasspath",
             "fooRuntimeOnly <- barRuntimeOnly"]
     )
     fun `Extending another test set should extend the configurations`(configs: String) {


### PR DESCRIPTION
Gradle 7 removes some APIs which have been marked as deprecated.
An example of such API is `sourceSet.compileConfigurationName`.
Testsets plugin uses some of the removed methods which casues build failures
with the following error message:
```
Caused by: java.lang.NoSuchMethodError:
'java.lang.String org.gradle.api.tasks.SourceSet.getCompileConfigurationName()'
```

Solves: #117