### PR TITLE
fix gradle 9 deprecations

### DIFF
--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/Gradle8CompatibilityTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/Gradle8CompatibilityTest.kt
@@ -1,0 +1,168 @@
+package org.unbrokendome.gradle.plugins.testsets
+
+import assertk.assertThat
+import assertk.assertions.isIn
+import assertk.assertions.isNotNull
+import assertk.assertions.prop
+import org.gradle.testkit.runner.BuildTask
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+
+class Gradle8CompatibilityTest : AbstractGradleIntegrationTest() {
+
+    abstract inner class AbstractVersionsCompatibilityTest {
+
+        @ValueSource(strings = [
+             "7.5.1", "7.6-rc-3"
+        ])
+        @ParameterizedTest(name = "Gradle {0}")
+        @DisplayName("Should work in Gradle version")
+        fun shouldWorkInGradleVersion(gradleVersion: String) {
+            val result = GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withGradleVersion(gradleVersion)
+                .withPluginClasspath()
+                .withArguments("integrationTest", "--info", "--stacktrace", "--warning-mode=fail")
+                .forwardOutput()
+                .build()
+
+            assertThat(result, "result")
+                .prop("for task integrationTest") { it.task(":integrationTest") }
+                .isNotNull()
+                .prop("outcome", BuildTask::getOutcome)
+                .isIn(TaskOutcome.NO_SOURCE, TaskOutcome.UP_TO_DATE)
+        }
+    }
+
+    @Nested
+    inner class GroovySinple : AbstractVersionsCompatibilityTest() {
+
+        @BeforeEach
+        fun setup() {
+            directory(projectDir) {
+                file("build.gradle", """ 
+                plugins {
+                    id('org.unbroken-dome.test-sets')
+                }
+                
+                testSets { integrationTest }
+            """)
+            }
+        }
+    }
+
+    @Nested
+    inner class KotlinSimple : AbstractVersionsCompatibilityTest() {
+
+        @BeforeEach
+        fun setup() {
+            directory(projectDir) {
+                file("build.gradle.kts", """ 
+                plugins {
+                    id("org.unbroken-dome.test-sets")
+                }
+                
+                testSets { create("integrationTest") }
+            """)
+            }
+        }
+    }
+
+    @Nested
+    inner class GroovyExtendsOtherTestSet : AbstractVersionsCompatibilityTest() {
+
+        @BeforeEach
+        fun setup() {
+            directory(projectDir) {
+                file("build.gradle", """ 
+                plugins {
+                    id('org.unbroken-dome.test-sets')
+                }
+                
+                testSets {
+                    extended
+                    
+                    integrationTest {
+                        extendsFrom extended
+                    }
+                }
+            """)
+            }
+        }
+    }
+
+    @Nested
+    inner class KotlinExtendsOtherTestSet : AbstractVersionsCompatibilityTest() {
+
+        @BeforeEach
+        fun setup() {
+            directory(projectDir) {
+                file("build.gradle.kts", """ 
+                plugins {
+                    id("org.unbroken-dome.test-sets")
+                }
+                
+                testSets {
+                    create("extended")
+                    
+                    create("integrationTest") {
+                        extendsFrom("extended")
+                    }
+                }
+            """)
+            }
+        }
+    }
+
+    @Nested
+    inner class GroovyLibraries : AbstractVersionsCompatibilityTest() {
+
+        @BeforeEach
+        fun setup() {
+            directory(projectDir) {
+                file("build.gradle", """ 
+                plugins {
+                    id('org.unbroken-dome.test-sets')
+                }
+                
+                testSets {
+                    libraries { testCommon }
+
+                    integrationTest {
+                        imports 'testCommon'
+                    }
+                }
+            """)
+            }
+        }
+    }
+
+    @Nested
+    inner class KotlinLibraries : AbstractVersionsCompatibilityTest() {
+
+        @BeforeEach
+        fun setup() {
+            directory(projectDir) {
+                file("build.gradle.kts", """ 
+                plugins {
+                    id("org.unbroken-dome.test-sets")
+                }
+                
+                testSets {
+                    val testCommon by libraries.creating
+
+                    create("integrationTest") {
+                        imports(testCommon)
+                    }
+                }
+            """)
+            }
+        }
+    }
+}

--- a/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/GradleVersionsCompatibilityTest.kt
+++ b/src/integrationTest/kotlin/org/unbrokendome/gradle/plugins/testsets/GradleVersionsCompatibilityTest.kt
@@ -19,7 +19,7 @@ class GradleVersionsCompatibilityTest : AbstractGradleIntegrationTest() {
     abstract inner class AbstractVersionsCompatibilityTest {
 
         @ValueSource(strings = [
-            "5.1.1", "5.6.4", "6.0.1", "6.8.3", "7.0"
+            "5.1.1", "5.6.4", "6.0.1", "6.8.3", "7.0", "7.5.1"
         ])
         @ParameterizedTest(name = "Gradle {0}")
         @DisplayName("Should work in Gradle version")

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSetContainer.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/dsl/TestSetContainer.kt
@@ -1,7 +1,7 @@
 package org.unbrokendome.gradle.plugins.testsets.dsl
 
-import groovy.lang.Closure
-import groovy.lang.DelegatesTo
+import javax.inject.Inject
+import kotlin.reflect.KClass
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.PolymorphicDomainObjectContainer
@@ -13,9 +13,6 @@ import org.gradle.internal.reflect.Instantiator
 import org.gradle.model.internal.core.NamedEntityInstantiator
 import org.unbrokendome.gradle.plugins.testsets.util.get
 import org.unbrokendome.gradle.plugins.testsets.util.sourceSets
-import org.unbrokendome.gradle.plugins.testsets.util.toAction
-import javax.inject.Inject
-import kotlin.reflect.KClass
 
 
 /**
@@ -46,27 +43,6 @@ interface TestSetContainer : PolymorphicDomainObjectContainer<TestSetBase> {
     fun createTestSet(name: String, configureAction: Action<TestSet>): TestSet =
         create(name, TestSet::class.java, configureAction)
 
-
-    /**
-     * Creates a new test set with the specified name, adds it to the container, and configures it
-     * with the specified closure.
-     *
-     * This variant is intended for Groovy DSL support, with an annotated closure parameter for better
-     * IDE support.
-     *
-     * @param name the name of the test set
-     * @param configureClosure a closure for configuring the test set
-     * @return the new [TestSet]
-     */
-    @JvmDefault
-    override fun create(
-        name: String,
-        @DelegatesTo(TestSet::class, strategy = Closure.DELEGATE_FIRST)
-        configureClosure: Closure<Any>
-    ): TestSet =
-        create(name, TestSet::class.java, configureClosure.toAction())
-
-
     /**
      * Creates a new test library with the specified name, and adds it to the container.
      *
@@ -89,26 +65,6 @@ interface TestSetContainer : PolymorphicDomainObjectContainer<TestSetBase> {
     @JvmDefault
     fun createLibrary(name: String, configureAction: Action<TestLibrary>): TestLibrary =
         create(name, TestLibrary::class.java, configureAction)
-
-
-    /**
-     * Creates a new test library with the specified name, adds it to the container, and configures it with
-     * the specified closure.
-     *
-     * This variant is intended for Groovy DSL support, with an annotated closure parameter for better
-     * IDE support.
-     *
-     * @param name the name of the test library
-     * @param configureClosure an closure for configuring the test library
-     * @return the new [TestLibrary]
-     */
-    @JvmDefault
-    fun createLibrary(
-        name: String,
-        @DelegatesTo(TestLibrary::class, strategy = Closure.DELEGATE_FIRST)
-        configureClosure: Closure<*>
-    ): TestLibrary =
-        createLibrary(name, configureClosure.toAction())
 
 
     /**
@@ -186,10 +142,6 @@ private open class DefaultTestSetContainer
 
     override fun create(name: String): TestSet =
         create(name, TestSet::class.java)
-
-
-    override fun create(name: String, configureClosure: Closure<Any>): TestSet =
-        create(name, TestSet::class.java, configureClosure.toAction())
 
 
     private val entityInstantiator = object : NamedEntityInstantiator<TestSetBase> {

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/util/ClosureExtensions.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/testsets/util/ClosureExtensions.kt
@@ -1,9 +1,0 @@
-package org.unbrokendome.gradle.plugins.testsets.util
-
-import groovy.lang.Closure
-import org.gradle.api.Action
-import org.gradle.util.ConfigureUtil
-
-
-fun <T : Any> Closure<*>.toAction(): Action<T> =
-        ConfigureUtil.configureUsing(this)


### PR DESCRIPTION
usage of ConfigureUtil is deprecated and about to be removed in gradle 8: https://docs.gradle.org/current/javadoc/org/gradle/util/ConfigureUtil.html

this PR removes usages of the class. it also adds some tests to ensure that the groovy dsl still works as the functions that accept closure were removed from _TestSetContainer_.

when using gradle 7.6:

```
$ gw --warning-mode all --stacktrace
Configuration on demand is an incubating feature.

> Configure project :app
The org.gradle.util.ConfigureUtil type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/7.6/userguide/upgrading_version_7.html#org_gradle_util_reports_deprecations
        at org.gradle.util.ConfigureUtil.logDeprecation(ConfigureUtil.java:216)
        at org.gradle.util.ConfigureUtil.configureUsing(ConfigureUtil.java:167)
        at org.unbrokendome.gradle.plugins.testsets.util.ClosureExtensionsKt.toAction(ClosureExtensions.kt:9)
        at org.unbrokendome.gradle.plugins.testsets.dsl.DefaultTestSetContainer.create(TestSetContainer.kt:192)
        at org.unbrokendome.gradle.plugins.testsets.dsl.DefaultTestSetContainer.create(TestSetContainer.kt:161)
```
