### PR TITLE
Update kotlin jvm version to v11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ configurations.named("integrationTestRuntimeOnly") {
 
 
 dependencies {
-    compileOnly(kotlin("stdlib-jdk8"))
+    compileOnly(kotlin("stdlib"))
 
     testImplementation(platform("org.junit:junit-bom:5.7.1"))
 
@@ -41,7 +41,7 @@ dependencies {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
         freeCompilerArgs = listOf("-Xjvm-default=enable")
     }
 }


### PR DESCRIPTION
Build fails because java and kotlin use different jvm version. See:

https://github.com/unbroken-dome/gradle-testsets-plugin/actions/runs/5991151019/job/16249196389